### PR TITLE
Update installation instructions to use snapshots

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val commonSettings = Seq(
   Compile / doc / scalacOptions ++= Seq("-groups", "-snippet-compiler:compile"),
   javaCppVersion := "1.5.9-SNAPSHOT",
   javaCppPlatform := Seq(),
-  resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots")
   // This is a hack to avoid depending on the native libs when publishing
   // but conveniently have them on the classpath during development.
   // There's probably a cleaner way to do this.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,20 +1,21 @@
 # Installation
 
-As Storch is still in an early stage of development, there are no published artifacts available yet. So for the time
-being, you have to build it from source:
+As Storch is still in an early stage of development, there are no releases available yet.
+We provide snapshots built from `main` though, to make it easier to already try Storch.
 
-```bash
-git clone https://github.com/sbrunk/storch
-cd storch
-sbt publishLocal
-```
+@:callout(info)
 
-Then, add Storch as a dependency to your project:
+Storch requires at least Scala 3.2
+
+@:@
+
+To use the snapshots, add a resolver for the sonatype snapshots repository and then add Storch as a dependency to your project:
 
 @:select(build-tool)
 
 @:choice(sbt)
 ```scala
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
 )
@@ -22,7 +23,8 @@ libraryDependencies += Seq(
 
 @:choice(scala-cli)
 ```scala
-//> using scala "3"
+//> using scala "3.2"
+//> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
 //> using lib "dev.storch::core:@VERSION@"
 ```
@@ -53,7 +55,7 @@ The easiest and most portable way to depend on the native library is via the PyT
 
 @:choice(sbt)
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
   "org.bytedeco" % "pytorch-platform" % "1.13.1-@JAVACPP_VERSION@"
@@ -63,6 +65,8 @@ fork := true
 
 @:choice(scala-cli)
 ```scala
+//> using scala "3.2"
+//> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
 //> using lib "dev.storch::core:@VERSION@"
 //> using lib "org.bytedeco:pytorch-platform:1.13.1-@JAVACPP_VERSION@"
@@ -85,7 +89,7 @@ Currently supported are `linux-x86_64`, `macosx-x86_64` and `windows-x86_64`.
 
 @:choice(sbt)
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
   "org.bytedeco" % "pytorch" % "1.13.1-@JAVACPP_VERSION@",
@@ -97,6 +101,8 @@ fork := true
 
 @:choice(scala-cli)
 ```scala
+//> using scala "3.2"
+//> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
 //> using lib "dev.storch::core:@VERSION@"
 //> using lib "org.bytedeco:openblas:0.3.21-@JAVACPP_VERSION@,classifier=linux-x86_64"
@@ -119,7 +125,7 @@ addSbtPlugin("org.bytedeco" % "sbt-javacpp" % "1.17")
 
 `build.sbt`:
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
 )
@@ -143,7 +149,7 @@ distribution including cuDNN, helping you to avoid having to mess with local CUD
 @:choice(sbt)
 
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
   "org.bytedeco" % "pytorch-platform-gpu" % "1.13.1-@JAVACPP_VERSION@",
@@ -154,6 +160,8 @@ fork := true
 
 @:choice(scala-cli)
 ```scala
+//> using scala "3.2"
+//> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
 //> using lib "dev.storch::core:@VERSION@"
 //> using lib "org.bytedeco:pytorch-platform-gpu:1.13.1-@JAVACPP_VERSION@"
@@ -175,7 +183,7 @@ Currently supported are `linux-x86_64-gpu` and `windows-x86_64-gpu`.
 
 @:choice(sbt)
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
   "org.bytedeco" % "pytorch" % "1.13.1-@JAVACPP_VERSION@",
@@ -188,6 +196,8 @@ fork := true
 
 @:choice(scala-cli)
 ```scala
+//> using scala "3.2"
+//> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
 //> using lib "dev.storch::core:@VERSION@"
 //> using lib "org.bytedeco:pytorch:1.13.1-@JAVACPP_VERSION@,classifier=linux-x86_64-gpu"
@@ -209,7 +219,7 @@ addSbtPlugin("org.bytedeco" % "sbt-javacpp" % "1.17")
 
 `build.sbt`:
 ```scala
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += Seq(
   "dev.storch" %% "core" % "@VERSION@",
 )

--- a/project/SiteSettings.scala
+++ b/project/SiteSettings.scala
@@ -83,7 +83,7 @@ object StorchSitePlugin extends AutoPlugin {
       .site
       .landingPage(
         logo = Some(
-          Image.internal(Root / "img" / "storch.svg", height = Some(Length(400, LengthUnit.px)))
+          Image.internal(Root / "img" / "storch.svg", height = Some(Length(300, LengthUnit.px)))
         ),
         title = Some("Storch"),
         subtitle = Some("GPU Accelerated Deep Learning for Scala 3"),

--- a/site/src/landing.template.html
+++ b/site/src/landing.template.html
@@ -73,6 +73,10 @@
     @:@
     ${cursor.currentDocument.content}
 
+    <div style="width: 40%; margin: auto;">
+      <script id="asciicast-548330" src="https://asciinema.org/a/548330.js" async data-autoplay="true" data-speed="32"></script>
+    </div>
+
     <p style="text-align: center; font-size: xx-small;"><a href="https://commons.wikimedia.org/wiki/File:Torch.svg">Torch</a> by Mailtoanton / CC BY-SA 3.0</p>
 
   </body>


### PR DESCRIPTION
With #8, we now publish snapshots from main, but to be able to close #1 we need docs on how to use them.

Also fixes a few more issues in the installation docs and adds the training loop demo to the landing page.