### PR TITLE
Add weight conversion and download of pre-trained resnet weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Storch - GPU Accelerated Deep Learning for Scala 3
 
-[![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/dev.storch/core_3?server=https%3A%2F%2Fs01.oss.sonatype.org)](https://s01.oss.sonatype.org/#nexus-search;gav~dev.storch~~~~)
-
 Storch is a Scala library for fast tensor computations and deep learning, based on PyTorch.
 
 Like PyTorch, Storch provides

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,9 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "org.bytedeco" % "pytorch" % s"$pytorchVersion-${javaCppVersion.value}",
       "org.typelevel" %% "spire" % "0.18.0",
+      "com.lihaoyi" %% "os-lib" % "0.9.0",
       "com.lihaoyi" %% "sourcecode" % "0.3.0",
+      "dev.dirs" % "directories" % "26",
       "org.scalameta" %% "munit" % "0.7.29" % Test,
       "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test
     )
@@ -103,7 +105,6 @@ lazy val examples = project
   .settings(
     fork := true,
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "os-lib" % "0.9.0",
       "me.tongfei" % "progressbar" % "0.9.5",
       "com.github.alexarchambault" %% "case-app" % "2.1.0-M24"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,8 @@ lazy val examples = project
     fork := true,
     libraryDependencies ++= Seq(
       "me.tongfei" % "progressbar" % "0.9.5",
-      "com.github.alexarchambault" %% "case-app" % "2.1.0-M24"
+      "com.github.alexarchambault" %% "case-app" % "2.1.0-M24",
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
     )
   )
   .dependsOn(vision)

--- a/core/src/main/scala/torch/hub.scala
+++ b/core/src/main/scala/torch/hub.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 storch.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package torch
+
+import dev.dirs.BaseDirectories
+import scala.io.Source
+import scala.util.Using
+import java.nio.file.Files
+import java.net.URL
+
+/** Utilities to download and cache pre-trained model weights. */
+object hub:
+  private val storchDir = os.Path(BaseDirectories.get().cacheDir) / "storch"
+  private val hubDir = storchDir / "hub"
+  private val modelDir = hubDir / "checkpoints"
+
+  def loadStateDictFromUrl(url: String): Map[String, Tensor[DType]] =
+    os.makeDir.all(modelDir)
+    val filename = os.Path(URL(url).getPath).last
+    val cachedFile = (modelDir / filename)
+    if !os.exists(cachedFile) then
+      System.err.println(s"Downloading: $url to $cachedFile")
+      Using.resource(URL(url).openStream()) { inputStream =>
+        Files.copy(inputStream, cachedFile.toNIO)
+      }
+    torch.pickleLoad(cachedFile.toNIO)

--- a/docs/pre-trained-weights.md
+++ b/docs/pre-trained-weights.md
@@ -1,0 +1,20 @@
+{%
+laika.title="Converting pre-trained weights"
+%}
+
+# Converting pre-trained weights from PyTorch
+
+Loading pre-trained weights from PyTorch into Storch is an important feature for transfer-learning,
+or for doing inference on models trained with PyTorch.
+
+Currently, this is not as simple as it should be because serialized weights cannot be loaded into Storch if they
+contain weights stored as `torch.nn.parameter.Parameter`, a subclass of `torch.Tensor`.
+We have to convert these parameters to regular tensors first to be able to load them in Storch.
+
+To help with this task, we provide a simple [conversion script](https://github.com/sbrunk/storch/blob/main/scripts/convert-weights/convert_weights.py).
+Currently the script only converts pre-trained ResNet weights but it shouldn't be too difficult to apply it to other weights as well.
+
+The [converted weights](https://github.com/sbrunk/storch/releases/tag/pretrained-weights) are also available for download
+from the Storch GitHub repository.
+
+We hope to improve the situation by creating our own reader that allows direct loading of PyTorch weights.

--- a/examples/src/main/scala/ImageClassifier.scala
+++ b/examples/src/main/scala/ImageClassifier.scala
@@ -17,10 +17,11 @@
 //> using scala "3.2"
 //> using repository "sonatype-s01:snapshots"
 //> using repository "sonatype:snapshots"
-//> using lib "dev.storch::vision:0.0-baeeb21-SNAPSHOT"
+//> using lib "dev.storch::vision:0.0-b34f589-SNAPSHOT"
 //> using lib "com.lihaoyi::os-lib:0.9.0"
 //> using lib "me.tongfei:progressbar:0.9.5"
 //> using lib "com.github.alexarchambault::case-app:2.1.0-M24"
+//> using lib "org.scala-lang.modules::scala-parallel-collections:1.0.4"
 //> using lib "org.bytedeco:pytorch-platform-gpu:1.13.1-1.5.9-SNAPSHOT"
 
 import Commands.*
@@ -39,6 +40,7 @@ import torch.optim.Adam
 import torchvision.models.resnet.{ResNet, ResNetVariant}
 
 import java.nio.file.Paths
+import scala.collection.parallel.CollectionConverters.ImmutableSeqIsParallelizable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -46,6 +48,8 @@ import scala.util.{Random, Try, Using}
 
 /** Example script for training an image-classification model on your own images */
 object ImageClassifier extends CommandsEntryPoint:
+
+  val fileTypes = Seq("jpg", "png")
 
   case class Metrics(loss: Float, accuracy: Float)
 
@@ -59,16 +63,37 @@ object ImageClassifier extends CommandsEntryPoint:
     println(s"Using device: $device")
 
     val datasetDir = os.Path(options.datasetDir, base = os.pwd)
+
+    /** verify that we can read all images of the dataset */
+    if os
+        .walk(datasetDir)
+        .filter(path => fileTypes.contains(path.ext))
+        .par
+        .map { path =>
+          val readTry = Try(ImmutableImage.loader().fromPath(path.toNIO)).map(_ => ())
+          readTry.failed.foreach(e => println(s"Could not read $path"))
+          readTry
+        }
+        .exists(_.isFailure)
+    then
+      println("Could not read all images in the dataset. Stopping.")
+      System.exit(1)
     val classes = os.list(datasetDir).filter(os.isDir).map(_.last).sorted
     val classIndices = classes.zipWithIndex.toMap
     println(s"Found ${classIndices.size} classes: ${classIndices.mkString("[", ", ", "]")}")
-    val pathsWithLabel = classes.flatMap { label =>
-      os
+    val pathsPerLabel = classes.map { label =>
+      label -> os
         .list(datasetDir / label)
-        .filter(_.ext == "jpg")
-        .map(path => path -> label)
-    }
+        .filter(path => fileTypes.contains(path.ext))
+    }.toMap
+    val pathsWithLabel =
+      pathsPerLabel.toSeq.flatMap((label, paths) => paths.map(path => path -> label))
     println(s"Found ${pathsWithLabel.size} examples")
+    println(
+      pathsPerLabel
+        .map((label, paths) => s"Found ${paths.size} examples for class $label")
+        .mkString("\n")
+    )
 
     val sample = random.shuffle(pathsWithLabel).take(options.take.getOrElse(pathsWithLabel.length))
     val (trainData, testData) = sample.splitAt((sample.size * 0.9).toInt)
@@ -76,10 +101,13 @@ object ImageClassifier extends CommandsEntryPoint:
     println(s"Eval size:  ${testData.size}")
 
     val model: ResNet[Float32] = options.baseModel.factory(numClasses = classes.length)
+    println(s"Model architecture: ${options.baseModel}")
     val transforms = options.baseModel.factory.DEFAULT.transforms
 
     if options.pretrained then
       val weights = torch.hub.loadStateDictFromUrl(options.baseModel.factory.DEFAULT.url)
+      // Don't load the classification head weights, as we they are specific to the imagenet classes
+      // and their output size (1000) usually won't match the number of classes of our dataset.
       model.loadStateDict(
         weights.filterNot((k, v) => Set("fc.weight", "fc.bias").contains(k))
       )
@@ -103,13 +131,9 @@ object ImageClassifier extends CommandsEntryPoint:
         .grouped(batchSize)
         .map { batch =>
           val (inputs, labels) = batch.unzip
+          // parallelize loading to improve GPU utilization
           val transformedInputs =
-            Await.result(
-              Future.traverse(inputs)(path => // parallelize loading to improve GPU utilization
-                Future(transforms.transforms(loader.fromPath(path.toNIO)))
-              ),
-              10.seconds
-            )
+            inputs.par.map(path => transforms.transforms(loader.fromPath(path.toNIO))).seq
           assert(transformedInputs.forall(t => !t.isnan.any.item))
           (
             transforms.batchTransforms(torch.stack(transformedInputs)),
@@ -196,24 +220,25 @@ object ImageClassifier extends CommandsEntryPoint:
       os.write(checkpointDir / "model.txt", options.baseModel.toString())
       os.write(checkpointDir / "classes.txt", classes.mkString("\n"))
 
-  def cleanup(datasetDir: String): Unit =
-    os.walk(os.Path(datasetDir, base = os.pwd)).filter(_.ext == "jpg").foreach { path =>
-      Try(ImmutableImage.loader().fromPath(path.toNIO)).recover { _ =>
-        println(s"Cleaning up broken image $path")
-        os.move(path, path / os.up / (path.last + ".bak"))
-      }
-    }
-
   case class Prediction(label: String, confidence: Double)
 
   def predict(options: PredictOptions): Prediction =
-    val classes = os.read.lines(os.Path(options.modelDir, os.pwd) / "classes.txt")
+    val modelDir = options.modelDir match
+      case None =>
+        val checkpoints = os.list(os.pwd / "checkpoints", sort = true)
+        if checkpoints.isEmpty then
+          println("Not checkpoint found. Did you train a model?")
+          System.exit(1)
+        checkpoints.last
+      case Some(value) => os.Path(value, os.pwd)
+    println(s"Trying to load model from $modelDir")
+    val classes = os.read.lines(modelDir / "classes.txt")
     val modelVariant =
-      ResNetVariant.valueOf(os.read(os.Path(options.modelDir, os.pwd) / "model.txt"))
+      ResNetVariant.valueOf(os.read(modelDir / "model.txt"))
     val model: ResNet[Float32] = modelVariant.factory(numClasses = classes.length)
     val transforms = modelVariant.factory.DEFAULT.transforms
     val ia = InputArchive()
-    ia.load_from((os.Path(options.modelDir, os.pwd) / "model.pt").toString)
+    ia.load_from((modelDir / "model.pt").toString)
     model.load(ia)
     model.eval()
     val image = ImmutableImage.loader().fromPath(Paths.get(options.imagePath))
@@ -238,9 +263,9 @@ case class TrainOptions(
     )
     datasetDir: String,
     @HelpMessage(
-      s"ResNet variant to use. Possible values are: ${ResNetVariant.values.mkString(", ")}"
+      s"ResNet variant to use. Possible values are: ${ResNetVariant.values.mkString(", ")}. Defaults to ResNet50."
     )
-    baseModel: ResNetVariant,
+    baseModel: ResNetVariant = ResNetVariant.ResNet50,
     @HelpMessage("Load pre-trained weights for base-model")
     pretrained: Boolean = true,
     @HelpMessage("Where to save model checkpoints")
@@ -256,8 +281,10 @@ case class TrainOptions(
 case class PredictOptions(
     @HelpMessage("Path to an image whose class we want to predict")
     imagePath: String,
-    @HelpMessage("Path to to the serialized model created by running 'train'")
-    modelDir: String
+    @HelpMessage(
+      "Path to to the serialized model created by running 'train'. Tries the latest model in 'checkpoints' if not set."
+    )
+    modelDir: Option[String]
 )
 
 object Commands:

--- a/scripts/convert-weights/convert_weights.py
+++ b/scripts/convert-weights/convert_weights.py
@@ -1,0 +1,20 @@
+# Script for converting weights of class `torch.nn.parameter.Parameter` to regular tensors which enables loading them from libtorch
+
+from pathlib import Path
+from urllib.parse import urlparse
+from torchvision.models.resnet import *
+import torch
+
+model_path = Path("models")
+model_path.mkdir(parents=True, exist_ok=True)
+
+for weights_enum in [ResNet18_Weights, ResNet34_Weights, ResNet50_Weights, ResNet101_Weights, ResNet152_Weights]:
+    for weights in weights_enum:
+        parts = urlparse(weights.url)
+        filename = Path(parts.path).name
+        print(f"Converting {filename}")
+        state_dict = weights.get_state_dict(progress=True)
+        # Convert from torch.nn.Parameter to torch.Tensor so we can load the state dict from libtorch
+        converted_state_dict = {k: v.clone().detach()
+                                for k, v in state_dict.items()}
+        torch.save(converted_state_dict, (model_path / filename))

--- a/scripts/convert-weights/requirements.txt
+++ b/scripts/convert-weights/requirements.txt
@@ -1,0 +1,4 @@
+torch==2.0.0
+torchvision==0.15.1
+
+


### PR DESCRIPTION
Loading pre-trained weights from PyTorch into Storch is an important feature for transfer-learning,
or for doing inference on models trained with PyTorch.

Currently, this is not as simple as it should be because serialized weights cannot be loaded into Storch if they
contain weights stored as `torch.nn.parameter.Parameter`, a subclass of `torch.Tensor`.
We have to convert these parameters to regular tensors first to be able to load them in Storch.

To help with this task, this PR adds a simple conversion script. Currently the script only converts pre-trained ResNet weights but it shouldn't be too difficult to apply it to other weights as well.

The [converted weights](https://github.com/sbrunk/storch/releases/tag/pretrained-weights) are also available for download from the Storch GitHub repository.

We might be able to get rid of this entirely by creating our own reader that allows direct loading of PyTorch weights.