### PR TITLE
Clone native tensor to avoid having buffers with corrupted data

### DIFF
--- a/core/src/main/scala/torch/Tensor.scala
+++ b/core/src/main/scala/torch/Tensor.scala
@@ -797,6 +797,7 @@ object Tensor:
               Array(data.length.toLong),
               NativeConverters.tensorOptions(inputDType, layout, CPU, requiresGrad)
             )
+            .clone()
         ).to(device = device)
       case data: U =>
         val dtype = scalaToDType(data)

--- a/core/src/test/scala/torch/TensorSuite.scala
+++ b/core/src/test/scala/torch/TensorSuite.scala
@@ -884,4 +884,17 @@ class TensorSuite extends TensorCheckSuite {
     ),
     expectedTensor = Tensor(Seq(0.0, 0.0, 0.0, 0.0, Double.NaN))
   )
+  test("Tensor creation properly handling buffers") {
+    val value = 100L
+    val data = Seq.fill(10000)(value)
+    val tensors = 1.to(1000).map { _ =>
+      Tensor(data)
+    }
+    assert(
+      tensors.forall { t =>
+        t.min().item == value &&
+        t.max().item == value
+      }
+    )
+  }
 }


### PR DESCRIPTION
Fixes #25