### PR TITLE
Fix torch.randn to use proper native function

### DIFF
--- a/core/src/main/scala/torch/Tensor.scala
+++ b/core/src/main/scala/torch/Tensor.scala
@@ -426,6 +426,9 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     */
   def t: Tensor[D] = Tensor(native.t())
 
+  /** Calculates the variance of all elements of this tensor. */
+  def variance = Tensor(native.`var`())
+
   /** Returns a new tensor with a dimension of size one inserted at the specified position.
     *
     * The returned tensor shares the same underlying data with this tensor.

--- a/core/src/main/scala/torch/torch.scala
+++ b/core/src/main/scala/torch/torch.scala
@@ -418,7 +418,7 @@ def randn[D <: FloatNN](
     requiresGrad: Boolean = false
 ): Tensor[D] =
   Tensor(
-    torchNative.torch_rand(
+    torchNative.torch_randn(
       size.toArray.map(_.toLong),
       NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)
     )

--- a/core/src/test/scala/torch/TensorSuite.scala
+++ b/core/src/test/scala/torch/TensorSuite.scala
@@ -106,6 +106,22 @@ class TensorSuite extends TensorCheckSuite {
     assertEquals(tensor(---, -1), Tensor(Seq(3, 7, 11, 15)))
   }
 
+  // Random sampling
+
+  test("randn.unit-test") {
+    val randnTensor = randn(Seq(100000))
+    val randnMean = randnTensor.mean
+    val expectedMean = Tensor(0.0).to(dtype = float32)
+    val randnVariance = randnTensor.variance
+    val expectedVariance = Tensor(1.0).to(dtype = float32)
+
+    assert(
+      allclose(randnMean, expectedMean, atol = 1e-2) &&
+        allclose(randnVariance, expectedVariance, atol = 1e-2)
+    )
+  }
+
+  // End Random sampling
   testUnaryOp(
     op = abs,
     opName = "abs",


### PR DESCRIPTION
Fix subtle bug with `torch.randn`, as it was mistakenly using `rand` under the hood.

I tried implementing a variance check as well, but I couldn't find the `var` function under javacpp. If anyone is able to help me I'd appreciate it.

As a side note, I will keep implementing more tensor ops soon, and improving test coverage to try to avoid these kind of subtle errors; a handful of them happened to me while implementing pointwise ops.