### PR TITLE
Implement update/setter for Tensor

### DIFF
--- a/core/src/main/scala/torch/Tensor.scala
+++ b/core/src/main/scala/torch/Tensor.scala
@@ -523,10 +523,10 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
 
   def zero(): Unit = native.zero_()
 
-  def index[T <: Boolean | Long: ClassTag](
+  private def nativeIndices[T <: Boolean | Long: ClassTag](
       indices: (Slice | Int | Long | Tensor[Bool] | Tensor[UInt8] | Tensor[Int64] | Seq[T] |
         None.type | Ellipsis)*
-  ): Tensor[D] =
+  ): TensorIndexArrayRef =
     def toSymInt(maybeLong: Option[Long]) = maybeLong.map(l => SymIntOptional(SymInt(l))).orNull
     // see https://pytorch.org/cppdocs/notes/tensor_indexing.html
     val nativeIndices: Seq[pytorch.TensorIndex] =
@@ -546,8 +546,34 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
         case s: Seq[T] @unchecked => new pytorch.TensorIndex(Tensor[T](s).native)
         case e: Ellipsis          => new pytorch.TensorIndex(new EllipsisIndexType)
         // TODO index with single boolean. Needs investigation why it is not mapped.
-    val ref = new pytorch.TensorIndexArrayRef(new pytorch.TensorIndexVector(nativeIndices.toArray*))
-    Tensor(native.index(ref))
+    new pytorch.TensorIndexArrayRef(new pytorch.TensorIndexVector(nativeIndices.toArray*))
+
+  def index[T <: Boolean | Long: ClassTag](
+      indices: (Slice | Int | Long | Tensor[Bool] | Tensor[UInt8] | Tensor[Int64] | Seq[T] |
+        None.type | Ellipsis)*
+  ): Tensor[D] =
+    Tensor(native.index(nativeIndices(indices*)))
+
+  /** Set tensor value(s) at indices
+    *
+    * @example
+    *   ```scala sc
+    *   val t = torch.zeros(Seq(2, 2))
+    *   // set first row to ones
+    *   t(Seq(0)) = 1
+    *   ```
+    */
+  def update[T <: Boolean | Long: ClassTag](
+      indices: Seq[
+        Slice | Int | Long | Tensor[Bool] | Tensor[UInt8] | Tensor[Int64] | Seq[T] | None.type |
+          Ellipsis
+      ],
+      values: Tensor[D] | ScalaType
+  ): this.type =
+    values match
+      case t: Tensor[D]            => native.index_put_(nativeIndices(indices*), t.native)
+      case s: ScalaType @unchecked => native.index_put_(nativeIndices(indices*), s.toScalar)
+    this
 
   def requiresGrad: Boolean = native.requires_grad()
 

--- a/core/src/main/scala/torch/ops/ReductionOps.scala
+++ b/core/src/main/scala/torch/ops/ReductionOps.scala
@@ -302,26 +302,6 @@ private[torch] trait ReductionOps {
     torchNative.logsumexp(input.native, dim.toArray, keepdim)
   )
 
-  /** Returns the mean value of all elements in the `input` tensor.
-    *
-    * @group reduction_ops
-    */
-  def mean[D <: FloatNN | ComplexNN](
-      input: Tensor[D]
-  ): Tensor[D] = Tensor(torchNative.mean(input.native))
-
-  /** Returns the mean value of all elements in the `input` tensor.
-    *
-    * @group reduction_ops
-    *
-    * @param dtype
-    *   ${reduceops_dtype}
-    */
-  def mean[D <: FloatNN | ComplexNN](
-      input: Tensor[?],
-      dtype: D
-  ): Tensor[D] = Tensor(torchNative.mean(input.native, new ScalarTypeOptional(dtype.toScalarType)))
-
   /** Returns the mean value of each row of the `input` tensor in the given dimension `dim`. If
     * `dim` is a list of dimensions, reduce over all of them.
     *
@@ -336,7 +316,7 @@ private[torch] trait ReductionOps {
     * @param dtype
     *   ${reduceops_dtype}
     */
-  def mean[D <: DType, D2 <: DType | Derive](
+  def mean[D <: FloatNN | ComplexNN, D2 <: FloatNN | ComplexNN | Derive](
       input: Tensor[D],
       dim: Int | Seq[Int] = Seq.empty,
       keepdim: Boolean = false,

--- a/core/src/test/scala/torch/TensorSuite.scala
+++ b/core/src/test/scala/torch/TensorSuite.scala
@@ -74,6 +74,20 @@ class TensorSuite extends TensorCheckSuite {
     assertEquals(tensor(---, -1), Tensor(Seq(3, 7, 11, 15)))
   }
 
+  test("update/setter") {
+    val tensor = torch.arange(0, 16).reshape(4, 4)
+    tensor(Seq(0)) = 20
+    assertEquals(tensor(0), torch.full(Seq(4), 20))
+
+    val updated = Tensor[Int](30)
+    tensor(Seq(1, 0)) = Tensor[Int](30)
+    assertEquals(tensor(1, 0), updated)
+
+    // copy column 1 to column 0
+    tensor(Seq(torch.Slice(), 1)) = tensor(torch.Slice(), 0)
+    assertEquals(tensor(torch.Slice(), 1), tensor(torch.Slice(), 0))
+  }
+
   test("Tensor creation properly handling buffers") {
     val value = 100L
     val data = Seq.fill(10000)(value)

--- a/core/src/test/scala/torch/ops/ReductionOpsSuite.scala
+++ b/core/src/test/scala/torch/ops/ReductionOpsSuite.scala
@@ -116,14 +116,14 @@ class ReductionOpsSuite extends TensorCheckSuite {
   // TODO unit test logsumexp
 
   testUnaryOp(
-    op = mean,
+    op = mean(_),
     opName = "mean",
     inputTensor = Tensor(Seq(0.2294, -0.5481, 1.3288)),
     expectedTensor = Tensor(0.3367)
   )
 
   test("mean with nan") {
-    assert(mean(Tensor(Seq(Float.NaN, 1, 2))).isnan.item)
+    assert(mean(Tensor[Float](Seq(Float.NaN, 1, 2))).isnan.item)
   }
 
   testUnaryOp(


### PR DESCRIPTION
Implement setter with indexing for tensors, analogous to the `index/apply` method for getting values/slices out.

```scala
val t = torch.zeros(Seq(2, 2))
// set first row to ones
t(Seq(0)) = 1 // syntactic sugar for t.update(Seq(0), 1)
```

I'm not super happy that we have to wrap the assignment indices in a seq, but I haven't found a way to get varargs working with the `update` method, as varags need to come last. Suggestions for improving the syntax appreciated.

See also https://contributors.scala-lang.org/t/allow-update-method-accept-varargs-of-its-first-parameter/5151