### PR TITLE
Fix return type of multinomial and add optional generator

### DIFF
--- a/core/src/main/scala/torch/ops/RandomSamplingOps.scala
+++ b/core/src/main/scala/torch/ops/RandomSamplingOps.scala
@@ -42,11 +42,10 @@ private[torch] trait RandomSamplingOps {
   def multinomial[D <: FloatNN](
       input: Tensor[D],
       numSamples: Long,
-      replacement: Boolean = false
+      replacement: Boolean = false,
+      generator: Option[Generator] | Generator = None
   ): Tensor[Int64] =
-    // TODO Handle Optional Generators properly
-    val generator = new org.bytedeco.pytorch.GeneratorOptional()
-    Tensor(torchNative.multinomial(input.native, numSamples, replacement, generator))
+    Tensor(torchNative.multinomial(input.native, numSamples, replacement, generator.toOptional))
 
 // TODO normal Returns a tensor of random numbers drawn from separate normal distributions whose mean and standard deviation are given.
 // TODO poisson Returns a tensor of the same size as input with each element sampled from a Poisson distribution with rate parameter given by the corresponding element in input i.e.,

--- a/core/src/main/scala/torch/ops/RandomSamplingOps.scala
+++ b/core/src/main/scala/torch/ops/RandomSamplingOps.scala
@@ -39,12 +39,11 @@ private[torch] trait RandomSamplingOps {
 // TODO bernoulli Draws binary random numbers (0 or 1) from a Bernoulli distribution.
 
   /* Returns a tensor where each row contains `numSamples` indices sampled from the multinomial probability distribution located in the corresponding row of tensor `input`. */
-// TODO Demote Float to Int
   def multinomial[D <: FloatNN](
       input: Tensor[D],
       numSamples: Long,
       replacement: Boolean = false
-  ): Tensor[D] =
+  ): Tensor[Int64] =
     // TODO Handle Optional Generators properly
     val generator = new org.bytedeco.pytorch.GeneratorOptional()
     Tensor(torchNative.multinomial(input.native, numSamples, replacement, generator))


### PR DESCRIPTION
This PR fixes the return type of the multinomial distribution to `int64`. This is justified as the underlying pytorch function always returns a long (as described in #54).  Furthermore, an additional optional argument is added that allows a generator to be passed to the function. 