### PR TITLE
Move tensor creation from native into it's own method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.3.0]
+        scala: [3.3.1]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -141,12 +141,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.3.0)
+      - name: Download target directories (3.3.1)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.1
 
-      - name: Inflate target directories (3.3.0)
+      - name: Inflate target directories (3.3.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val pytorchVersion = "2.0.1"
 val cudaVersion = "12.1-8.9"
 val openblasVersion = "0.3.23"
 val mklVersion = "2023.1"
-ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / javaCppVersion := "1.5.10-SNAPSHOT"
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 

--- a/core/src/main/scala/torch/Generator.scala
+++ b/core/src/main/scala/torch/Generator.scala
@@ -18,6 +18,7 @@ package torch
 
 import org.bytedeco.pytorch.global.torch.make_generator_cpu
 import org.bytedeco.pytorch.global.torch_cuda.make_generator_cuda
+import torch.internal.NativeConverters.fromNative
 
 /** Creates and returns a generator object that manages the state of the algorithm which produces
   * pseudo random numbers.
@@ -29,7 +30,7 @@ class Generator(val device: Device = Device.CPU) {
     case _               => throw new IllegalArgumentException("Unsupported generator device")
 
   /** Returns the Generator state as a [[torch.Tensor[UInt8]]. */
-  def getState: Tensor[UInt8] = Tensor(native.get_state())
+  def getState: Tensor[UInt8] = fromNative(native.get_state())
 
   /** Sets the Generator state.
     *

--- a/core/src/main/scala/torch/Tensor.scala
+++ b/core/src/main/scala/torch/Tensor.scala
@@ -82,13 +82,13 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
 
   def ==(other: ScalaType): Tensor[Bool] = eq(other)
 
-  def add[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = Tensor(
+  def add[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = fromNative(
     native.add(toScalar(s))
   )
 
   def +[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = add(s)
 
-  def add[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = Tensor(
+  def add[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = fromNative(
     native.add(other.native)
   )
 
@@ -105,13 +105,13 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     native.add_(toScalar(s))
     this
 
-  def sub[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = Tensor(
+  def sub[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = fromNative(
     native.sub(toScalar(s))
   )
 
   def -[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = sub(s)
 
-  def sub[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = Tensor(
+  def sub[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = fromNative(
     native.sub(other.native)
   )
 
@@ -125,13 +125,13 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     native.sub_(toScalar(s))
     this
 
-  def mul[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = Tensor(
+  def mul[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = fromNative(
     native.mul(toScalar(s))
   )
 
   def *[S <: ScalaType](s: S): Tensor[Promoted[D, ScalaToDType[S]]] = mul(s)
 
-  def mul[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = Tensor(
+  def mul[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] = fromNative(
     native.mul(other.native)
   )
 
@@ -145,14 +145,14 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     native.mul_(toScalar(s))
     this
 
-  def div[S <: ScalaType](s: S): Tensor[Div[D, ScalaToDType[S]]] = Tensor(
+  def div[S <: ScalaType](s: S): Tensor[Div[D, ScalaToDType[S]]] = fromNative(
     native.div(toScalar(s))
   )
 
   def /[S <: ScalaType](s: S): Tensor[Div[D, ScalaToDType[S]]] = div(s)
 
   /** Divides each element of this tensor by the corresponding element of `other`. * */
-  def div[D2 <: DType](other: Tensor[D2]): Tensor[Div[D, D2]] = Tensor(native.div(other.native))
+  def div[D2 <: DType](other: Tensor[D2]): Tensor[Div[D, D2]] = fromNative(native.div(other.native))
 
   /** Divides each element of this tensor by the corresponding element of `other`. * */
   def /[D2 <: DType](other: Tensor[D2]): Tensor[Div[D, D2]] = div(other)
@@ -171,14 +171,14 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
   ): Tensor[D] = index(indices*)
 
   /** Computes the absolute value of each element. */
-  def abs: Tensor[D] = Tensor(native.abs())
+  def abs: Tensor[D] = fromNative(native.abs())
 
-  def acos: Tensor[D] = Tensor(native.acos())
+  def acos: Tensor[D] = fromNative(native.acos())
 
-  def adjoint: Tensor[D] = Tensor(native.adjoint())
+  def adjoint: Tensor[D] = fromNative(native.adjoint())
 
   /** Tests if all elements of this tensor evaluate to `true`. */
-  def all: Tensor[Bool] = Tensor(native.all())
+  def all: Tensor[Bool] = fromNative(native.all())
 
   /** @see [[torch.allclose]] */
   def allclose(
@@ -188,10 +188,10 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       equalNan: Boolean = false
   ) = native.allclose(other.native, rtol, atol, equalNan)
 
-  def any: Tensor[Bool] = Tensor(native.any())
+  def any: Tensor[Bool] = fromNative(native.any())
 
   /** Tests if any element of this tensor evaluates to `true`. */
-  def any(dim: Int, keepdim: Boolean = true): Tensor[Bool] = Tensor(native.any(dim, keepdim))
+  def any(dim: Int, keepdim: Boolean = true): Tensor[Bool] = fromNative(native.any(dim, keepdim))
 
   /** Returns the indices of the maximum value of all elements in the tensor.
     *
@@ -209,7 +209,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     * @param keepdim
     * @return
     */
-  def argmax(dim: Int | Option[Int] = None, keepdim: Boolean = false): Tensor[Int64] = Tensor(
+  def argmax(dim: Int | Option[Int] = None, keepdim: Boolean = false): Tensor[Int64] = fromNative(
     native.argmax(NativeConverters.toOptional(dim), keepdim)
   )
 
@@ -245,7 +245,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     * This method also affects forward mode AD gradients and the result will never have forward mode
     * AD gradients.
     */
-  def detach(): Tensor[D] = Tensor(native.detach())
+  def detach(): Tensor[D] = fromNative(native.detach())
 
   /** Returns a copy of `input`.
     *
@@ -255,9 +255,9 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     *   `Tensor.detach`.
     */
   def clone(memoryFormat: MemoryFormat = MemoryFormat.Preserve): Tensor[D] =
-    Tensor(native.clone(memoryFormat.toNativeOptional))
+    fromNative(native.clone(memoryFormat.toNativeOptional))
 
-  def contiguous: Tensor[D] = Tensor(native.contiguous())
+  def contiguous: Tensor[D] = fromNative(native.contiguous())
 
   /** Copies the elements from `src` into this tensor and returns this.
     *
@@ -275,7 +275,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     this
 
   /** Returns a new tensor with the sine of the elements of this tensor. */
-  def cos: Tensor[FloatPromoted[D]] = Tensor(native.cos())
+  def cos: Tensor[FloatPromoted[D]] = fromNative(native.cos())
 
   def device: Device = Device(native.device())
 
@@ -284,13 +284,13 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
   def dtype: D
 
   /** Computes element-wise equality */
-  def eq(other: ScalaType): Tensor[Bool] = Tensor(native.eq(toScalar(other)))
+  def eq(other: ScalaType): Tensor[Bool] = fromNative(native.eq(toScalar(other)))
 
   /** Computes element-wise equality
     *
     * The argument can be a tensor whose shape is broadcastable with this tensor.
     */
-  def eq(other: Tensor[?]): Tensor[Bool] = Tensor(native.eq(other.native))
+  def eq(other: Tensor[?]): Tensor[Bool] = fromNative(native.eq(other.native))
 
   def ==(other: Tensor[?]): Tensor[Bool] = eq(other)
 
@@ -303,7 +303,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
   def equal(other: Tensor[D]): Boolean = native.equal(other.native)
 
   /** Returns the tensor with elements exponentiated. */
-  def exp: Tensor[D] = Tensor(native.exp())
+  def exp: Tensor[D] = fromNative(native.exp())
 
   /** Returns a new view of this tensor with singleton dimensions expanded to a larger size.
     *
@@ -333,25 +333,25 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     *   x.expand(-1, 4) // -1 means not changing the size of that dimension
     *   ```
     */
-  def expand(sizes: Int*) = Tensor(native.expand(sizes.map(_.toLong)*))
+  def expand(sizes: Int*) = fromNative(native.expand(sizes.map(_.toLong)*))
 
-  def flatten: Tensor[D] = Tensor(native.flatten())
+  def flatten: Tensor[D] = fromNative(native.flatten())
 
-  def flatten(startDim: Int = 0, endDim: Int = -1): Tensor[D] = Tensor(
+  def flatten(startDim: Int = 0, endDim: Int = -1): Tensor[D] = fromNative(
     native.flatten(startDim, endDim)
   )
 
   def float: Tensor[Float32] = to(dtype = float32)
 
   /** Divides each element of this tensor by `s` and floors the result. */
-  def floorDivide[S <: ScalaType](s: S): Tensor[Div[D, ScalaToDType[S]]] = Tensor(
+  def floorDivide[S <: ScalaType](s: S): Tensor[Div[D, ScalaToDType[S]]] = fromNative(
     native.floor_divide(toScalar(s))
   )
 
   /** Divides each element of this tensor by the corresponding element of `other` and floors the
     * result.
     */
-  def floorDivide[D2 <: DType](other: Tensor[D2]): Tensor[Div[D, D2]] = Tensor(
+  def floorDivide[D2 <: DType](other: Tensor[D2]): Tensor[Div[D, D2]] = fromNative(
     native.floor_divide(other.native)
   )
 
@@ -361,13 +361,13 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     */
   def grad: Option[Tensor[D]] =
     val nativeGrad = native.grad()
-    Option.when(nativeGrad.defined())(Tensor(nativeGrad))
+    Option.when(nativeGrad.defined())(fromNative(nativeGrad))
 
-  def ge(other: ScalaType): Tensor[Bool] = Tensor(native.ge(toScalar(other)))
+  def ge(other: ScalaType): Tensor[Bool] = fromNative(native.ge(toScalar(other)))
 
   def >=(other: ScalaType): Tensor[Bool] = ge(other)
 
-  def gt(other: ScalaType): Tensor[Bool] = Tensor(native.gt(toScalar(other)))
+  def gt(other: ScalaType): Tensor[Bool] = fromNative(native.gt(toScalar(other)))
 
   def >(other: ScalaType): Tensor[Bool] = gt(other)
 
@@ -377,7 +377,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
 
   def isQuantized: Boolean = native.is_quantized()
 
-  def isnan: Tensor[Bool] = Tensor(native.isnan())
+  def isnan: Tensor[Bool] = fromNative(native.isnan())
 
   def isNonzero: Boolean = native.is_nonzero()
 
@@ -415,25 +415,25 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
   def layout: Layout = Layout.fromNative(native.layout())
 
   /** Returns the tensor with elements logged. */
-  def log: Tensor[D] = Tensor(native.log())
+  def log: Tensor[D] = fromNative(native.log())
 
   def long: Tensor[Int64] = to(dtype = int64)
 
-  def le(other: ScalaType): Tensor[Bool] = Tensor(native.le(toScalar(other)))
+  def le(other: ScalaType): Tensor[Bool] = fromNative(native.le(toScalar(other)))
 
   def <=(other: ScalaType): Tensor[Bool] = le(other)
 
-  def lt(other: ScalaType): Tensor[Bool] = Tensor(native.lt(toScalar(other)))
+  def lt(other: ScalaType): Tensor[Bool] = fromNative(native.lt(toScalar(other)))
 
   def <(other: ScalaType): Tensor[Bool] = lt(other)
 
   def matmul[D2 <: DType](u: Tensor[D2]): Tensor[Promoted[D, D2]] =
-    Tensor[Promoted[D, D2]](native.matmul(u.native))
+    fromNative(native.matmul(u.native))
 
   def `@`[D2 <: DType](u: Tensor[D2]): Tensor[Promoted[D, D2]] = matmul(u)
 
   /** Returns the maximum value of all elements of this tensor. */
-  def max(): Tensor[D] = Tensor(native.max())
+  def max(): Tensor[D] = fromNative(native.max())
 
   /** Returns a tuple ``(values, indices)`` where ``values`` is the maximum value of each row of the
     * `input` tensor in the given dimension `dim`. And ``indices`` is the index location of each
@@ -450,12 +450,12 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     */
   def max(dim: Long, keepdim: Boolean = false): TensorTuple[D] =
     val nativeTuple = native.max(dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(values = fromNative(nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
 
   def maximum[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] =
-    Tensor[Promoted[D, D2]](native.maximum(other.native))
+    fromNative[Promoted[D, D2]](native.maximum(other.native))
 
-  def mean: Tensor[D] = Tensor(native.mean())
+  def mean: Tensor[D] = fromNative(native.mean())
 
   /** @see
     *   [[torch.mean]]
@@ -468,7 +468,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     val derivedDType = dtype match
       case _: Derive => this.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.mean(
         native,
         dim.toArray,
@@ -477,27 +477,27 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       )
     )
 
-  def min(): Tensor[Int64] = Tensor[Int64](native.min())
+  def min(): Tensor[Int64] = fromNative(native.min())
 
   def minimum[D2 <: DType](other: Tensor[D2]): Tensor[Promoted[D, D2]] =
-    Tensor[Promoted[D, D2]](native.minimum(other.native))
+    fromNative[Promoted[D, D2]](native.minimum(other.native))
 
   /** Accessing this property is equivalent to calling adjoint(). */
-  def mH: Tensor[D] = Tensor(native.mH())
+  def mH: Tensor[D] = fromNative(native.mH())
 
   /** Returns a view of this tensor with the last two dimensions transposed.
     *
     * `x.mT` is equivalent to `x.transpose(-2, -1)`.
     */
-  def mT: Tensor[D] = Tensor(native.mT())
+  def mT: Tensor[D] = fromNative(native.mT())
 
   /** Returns a new tensor with the negative of the elements of this tensor. */
-  def neg: Tensor[D] = Tensor(native.neg())
+  def neg: Tensor[D] = fromNative(native.neg())
 
   /** Returns the total number of elements in the input tensor. */
   def numel: Long = native.numel()
 
-  def permute(dims: Int*): Tensor[D] = Tensor(native.permute(dims.map(_.toLong)*))
+  def permute(dims: Int*): Tensor[D] = fromNative(native.permute(dims.map(_.toLong)*))
 
   /** @see [[torch.pow]] */
   def pow[D2 <: DType](exponent: Tensor[D2])(using
@@ -505,7 +505,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       ev1: Promoted[D, D2] NotEqual Bool,
       @implicitNotFound(""""pow" not implemented for complex32""")
       ev2: Promoted[D, D2] NotEqual Complex32
-  ): Tensor[Promoted[D, D2]] = Tensor(
+  ): Tensor[Promoted[D, D2]] = fromNative(
     native.pow(exponent.native)
   )
 
@@ -515,11 +515,11 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       ev1: Promoted[D, ScalaToDType[S]] NotEqual Bool,
       @implicitNotFound(""""pow" not implemented for complex32""")
       ev2: Promoted[D, ScalaToDType[S]] NotEqual Complex32
-  ): Tensor[Promoted[D, ScalaToDType[S]]] = Tensor(
+  ): Tensor[Promoted[D, ScalaToDType[S]]] = fromNative(
     native.pow(exponent.toScalar)
   )
 
-  def prod[D <: DType](dtype: D = this.dtype) = Tensor(native.prod())
+  def prod[D <: DType](dtype: D = this.dtype) = fromNative(native.prod())
 
   /** Repeats this tensor along the specified dimensions.
     *
@@ -528,38 +528,38 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     * @param sizes
     *   The number of times to repeat this tensor along each dimension
     */
-  def repeat(sizes: Int*): Tensor[D] = Tensor(native.repeat(sizes.map(_.toLong)*))
+  def repeat(sizes: Int*): Tensor[D] = fromNative(native.repeat(sizes.map(_.toLong)*))
 
-  def reshape(shape: Int*): Tensor[D] = Tensor(native.reshape(shape.map(_.toLong)*))
+  def reshape(shape: Int*): Tensor[D] = fromNative(native.reshape(shape.map(_.toLong)*))
 
   def shape: Seq[Int] = size
 
-  def square = Tensor(native.square())
+  def square = fromNative(native.square())
 
-  def squeeze: Tensor[D] = Tensor(native.squeeze())
+  def squeeze: Tensor[D] = fromNative(native.squeeze())
 
   def size: Seq[Int] = ArraySeq.unsafeWrapArray(native.sizes.vec.get.map(_.toInt))
 
-  def std: Tensor[D] = Tensor[D](native.std())
+  def std: Tensor[D] = fromNative(native.std())
 
   /** Returns a new tensor with the sine of the elements of this tensor. */
-  def sin: Tensor[FloatPromoted[D]] = Tensor(native.sin())
+  def sin: Tensor[FloatPromoted[D]] = fromNative(native.sin())
 
   /** Returns the sum of all elements of this tensor. */
-  def sum: Tensor[Sum[D]] = Tensor(native.sum())
+  def sum: Tensor[Sum[D]] = fromNative(native.sum())
 
   /** Expects `input` to be \<= 2-D tensor and transposes dimensions 0 and 1.
     *
     * 0-D and 1-D tensors are returned as is. When input is a 2-D tensor this is equivalent to
     * `transpose(input, 0, 1)`.
     */
-  def t: Tensor[D] = Tensor(native.t())
+  def t: Tensor[D] = fromNative(native.t())
 
   /** Calculates the variance of all elements of this tensor. */
-  def variance = Tensor(native.`var`())
+  def variance = fromNative(native.`var`())
 
   /** Returns a new tensor with the negative of the elements of this tensor. */
-  def unary_- : Tensor[D] = Tensor(native.neg())
+  def unary_- : Tensor[D] = fromNative(native.neg())
 
   /** Returns a new tensor with a dimension of size one inserted at the specified position.
     *
@@ -584,7 +584,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     * @param dim
     *   the index at which to insert the singleton dimension
     */
-  def unsqueeze(dim: Int): Tensor[D] = Tensor(native.unsqueeze(dim))
+  def unsqueeze(dim: Int): Tensor[D] = fromNative(native.unsqueeze(dim))
 
   def zero(): Unit = native.zero_()
 
@@ -617,7 +617,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       indices: (Slice | Int | Long | Tensor[Bool] | Tensor[UInt8] | Tensor[Int64] | Seq[T] |
         None.type | Ellipsis)*
   ): Tensor[D] =
-    Tensor(native.index(nativeIndices(indices*)))
+    fromNative(native.index(nativeIndices(indices*)))
 
   /** Set tensor value(s) at indices
     *
@@ -653,10 +653,10 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
         case i: Int      => native.split(i.toLong, dim.toLong)
         case s: Seq[Int] => native.split(s.map(_.toLong).toArray, dim.toLong)
       }
-    (0L until result.size()).map(i => Tensor(result.get(i)))
+    (0L until result.size()).map(i => fromNative(result.get(i)))
   }
 
-  def take(indices: Tensor[Int64]): Tensor[D] = Tensor(native.take(indices.native))
+  def take(indices: Tensor[Int64]): Tensor[D] = fromNative(native.take(indices.native))
 
   def takeAlongDim(indices: Tensor[Int64], dim: Int) =
     native.take_along_dim(indices.native, toOptional(dim))
@@ -679,7 +679,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
     val targetDType = dtype.toScalarType
     if dtype == this.dtype && device == this.device && !copy then this.asInstanceOf[Tensor[U]]
     else if device == this.device then
-      Tensor(
+      fromNative(
         native.to(
           targetDType,
           nonBlocking,
@@ -688,7 +688,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
         )
       )
     else
-      Tensor(
+      fromNative(
         native.to(
           device.toNative,
           targetDType,
@@ -749,7 +749,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
   def toSeq: Seq[DTypeToScala[D]] = ArraySeq.unsafeWrapArray(toArray)
 
   /** Returns the sum of the elements of the diagonal of the input 2-D matrix. */
-  def trace: Tensor[D] = Tensor(native.trace)
+  def trace: Tensor[D] = fromNative(native.trace)
 
   /** Returns a summary of the contents of this tensor.
     *
@@ -809,7 +809,7 @@ sealed abstract class Tensor[D <: DType]( /* private[torch]  */ val native: pyto
       info + " " + (if !flattened then "\n" else ": ") + summarize(this, maxEntries)
     else summarize(this, maxEntries)
 
-  def view(shape: Int*): Tensor[D] = Tensor(native.view(shape.map(_.toLong)*))
+  def view(shape: Int*): Tensor[D] = fromNative(native.view(shape.map(_.toLong)*))
 
   def info: String =
     s"tensor dtype=${dtype.toString}, shape=${size.mkString("[", ", ", "]")}, device=${device.device}"
@@ -909,28 +909,29 @@ type ComplexTensor = Complex32Tensor | Complex64Tensor | Complex128Tensor
 
 object Tensor:
 
-  def apply[D <: DType](native: pytorch.Tensor): Tensor[D] = (native.scalar_type().intern() match
-    case ScalarType.Byte          => new UInt8Tensor(native)
-    case ScalarType.Char          => new Int8Tensor(native)
-    case ScalarType.Short         => new Int16Tensor(native)
-    case ScalarType.Int           => new Int32Tensor(native)
-    case ScalarType.Long          => new Int64Tensor(native)
-    case ScalarType.Half          => new Float16Tensor(native)
-    case ScalarType.Float         => new Float32Tensor(native)
-    case ScalarType.Double        => new Float64Tensor(native)
-    case ScalarType.ComplexHalf   => new Complex32Tensor(native)
-    case ScalarType.ComplexFloat  => new Complex64Tensor(native)
-    case ScalarType.ComplexDouble => new Complex128Tensor(native)
-    case ScalarType.Bool          => new BoolTensor(native)
-    case ScalarType.QInt8         => new QInt8Tensor(native)
-    case ScalarType.QUInt8        => new QUInt8Tensor(native)
-    case ScalarType.QInt32        => new QInt32Tensor(native)
-    case ScalarType.BFloat16      => new BFloat16Tensor(native)
-    case ScalarType.QUInt4x2      => new QUInt4x2Tensor(native)
-    case ScalarType.QUInt2x4      => new QUInt2x4Tensor(native)
-    case ScalarType.Undefined     => new UndefinedTensor(native)
-    case ScalarType.NumOptions    => new NumOptionsTensor(native)
-  ).asInstanceOf[Tensor[D]]
+  def fromNative[D <: DType](native: pytorch.Tensor): Tensor[D] =
+    (native.scalar_type().intern() match
+      case ScalarType.Byte          => new UInt8Tensor(native)
+      case ScalarType.Char          => new Int8Tensor(native)
+      case ScalarType.Short         => new Int16Tensor(native)
+      case ScalarType.Int           => new Int32Tensor(native)
+      case ScalarType.Long          => new Int64Tensor(native)
+      case ScalarType.Half          => new Float16Tensor(native)
+      case ScalarType.Float         => new Float32Tensor(native)
+      case ScalarType.Double        => new Float64Tensor(native)
+      case ScalarType.ComplexHalf   => new Complex32Tensor(native)
+      case ScalarType.ComplexFloat  => new Complex64Tensor(native)
+      case ScalarType.ComplexDouble => new Complex128Tensor(native)
+      case ScalarType.Bool          => new BoolTensor(native)
+      case ScalarType.QInt8         => new QInt8Tensor(native)
+      case ScalarType.QUInt8        => new QUInt8Tensor(native)
+      case ScalarType.QInt32        => new QInt32Tensor(native)
+      case ScalarType.BFloat16      => new BFloat16Tensor(native)
+      case ScalarType.QUInt4x2      => new QUInt4x2Tensor(native)
+      case ScalarType.QUInt2x4      => new QUInt2x4Tensor(native)
+      case ScalarType.Undefined     => new UndefinedTensor(native)
+      case ScalarType.NumOptions    => new NumOptionsTensor(native)
+    ).asInstanceOf[Tensor[D]]
 
   /** Constructs a tensor with no autograd history (also known as a “leaf tensor”) by copying data.
     */
@@ -986,7 +987,7 @@ object Tensor:
                 s"Unsupported data type ${summon[ClassTag[U]].runtimeClass.getSimpleName}"
               )
 
-        Tensor(
+        fromNative(
           torchNative
             .from_blob(
               pointer,
@@ -1005,7 +1006,7 @@ object Tensor:
       requiresGrad: Boolean = false
   ): Tensor[ScalaToDType[S]] =
     val dtype = scalaToDType(s)
-    Tensor(
+    fromNative(
       torchNative.scalar_tensor(
         NativeConverters.toScalar(s),
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)

--- a/core/src/main/scala/torch/internal/NativeConverters.scala
+++ b/core/src/main/scala/torch/internal/NativeConverters.scala
@@ -161,3 +161,5 @@ private[torch] object NativeConverters:
         increment = it => it.increment(),
         access = it => it.access()
       )
+
+  export Tensor.fromNative

--- a/core/src/main/scala/torch/nn/functional/Activations.scala
+++ b/core/src/main/scala/torch/nn/functional/Activations.scala
@@ -21,7 +21,7 @@ package functional
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.global.torch as torchNative
 import org.bytedeco.javacpp.LongPointer
-import torch.internal.NativeConverters.toOptional
+import torch.internal.NativeConverters.{fromNative, toNative, toOptional}
 import org.bytedeco.pytorch.{ScalarTypeOptional, TensorOptional}
 
 private[torch] trait Activations {
@@ -41,7 +41,7 @@ private[torch] trait Activations {
   ): Tensor[Out] =
     val nativeDType =
       if dtype == input.dtype then ScalarTypeOptional() else ScalarTypeOptional(dtype.toScalarType)
-    Tensor(torchNative.log_softmax(input.native, dim, nativeDType))
+    fromNative(torchNative.log_softmax(input.native, dim, nativeDType))
 
     /** Applies the rectified linear unit function element-wise.
       *
@@ -49,7 +49,7 @@ private[torch] trait Activations {
       *
       * @group nn_activation
       */
-  def relu[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.relu(input.native))
+  def relu[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(torchNative.relu(input.native))
 
   /** Applies the element-wise function $\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}$
     *
@@ -57,14 +57,16 @@ private[torch] trait Activations {
     *
     * @group nn_activation
     */
-  def sigmoid[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.sigmoid(input.native))
+  def sigmoid[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(
+    torchNative.sigmoid(input.native)
+  )
 
   /** Applies the Sigmoid Linear Unit (SiLU) function, element-wise. The SiLU function is also known
     * as the swish function.
     *
     * @group nn_activation
     */
-  def silu[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.silu(input.native))
+  def silu[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(torchNative.silu(input.native))
 
   /** Applies a softmax function.
     *
@@ -75,5 +77,5 @@ private[torch] trait Activations {
   ): Tensor[Out] =
     val nativeDType =
       if dtype == input.dtype then ScalarTypeOptional() else ScalarTypeOptional(dtype.toScalarType)
-    Tensor(torchNative.softmax(input.native, dim, nativeDType))
+    fromNative(torchNative.softmax(input.native, dim, nativeDType))
 }

--- a/core/src/main/scala/torch/nn/functional/Convolution.scala
+++ b/core/src/main/scala/torch/nn/functional/Convolution.scala
@@ -38,7 +38,7 @@ private[torch] trait Convolution {
       dilation: Int = 1,
       groups: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv1d(
         input.native,
         weight.native,
@@ -63,7 +63,7 @@ private[torch] trait Convolution {
       dilation: Int | (Int, Int) = 1,
       groups: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv2d(
         input.native,
         weight.native,
@@ -88,7 +88,7 @@ private[torch] trait Convolution {
       dilation: Int = 1,
       groups: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv3d(
         input.native,
         weight.native,
@@ -115,7 +115,7 @@ private[torch] trait Convolution {
       groups: Int = 1,
       dilation: Int | (Int, Int) = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv_transpose1d(
         input.native,
         weight.native,
@@ -143,7 +143,7 @@ private[torch] trait Convolution {
       groups: Int = 1,
       dilation: Int | (Int, Int) = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv_transpose2d(
         input.native,
         weight.native,
@@ -171,7 +171,7 @@ private[torch] trait Convolution {
       groups: Int = 1,
       dilation: Int | (Int, Int) = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.conv_transpose3d(
         input.native,
         weight.native,

--- a/core/src/main/scala/torch/nn/functional/Dropout.scala
+++ b/core/src/main/scala/torch/nn/functional/Dropout.scala
@@ -17,7 +17,9 @@
 package torch
 package nn
 package functional
+
 import org.bytedeco.pytorch.global.torch as torchNative
+import torch.internal.NativeConverters.fromNative
 
 private[torch] trait Dropout {
 
@@ -30,7 +32,7 @@ private[torch] trait Dropout {
     * @group nn_dropout
     */
   def dropout[D <: DType](input: Tensor[D], p: Double = 0.5, training: Boolean = true): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.dropout(input.native, p, training)
     )
 

--- a/core/src/main/scala/torch/nn/functional/Linear.scala
+++ b/core/src/main/scala/torch/nn/functional/Linear.scala
@@ -22,7 +22,7 @@ import org.bytedeco.javacpp.LongPointer
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.TensorOptional
 import org.bytedeco.pytorch.global.torch as torchNative
-import torch.internal.NativeConverters.toOptional
+import torch.internal.NativeConverters.{fromNative, toOptional}
 
 // Linear functions
 private[torch] trait Linear {
@@ -54,7 +54,7 @@ private[torch] trait Linear {
       weight: Tensor[D],
       bias: Tensor[D] | Option[Tensor[D]] = None
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.linear(input.native, weight.native, toOptional(bias))
     )
 
@@ -77,7 +77,7 @@ private[torch] trait Linear {
       input2: Tensor[D],
       weight: Tensor[D],
       bias: Tensor[D] | Option[Tensor[D]] = None
-  ): Tensor[D] = Tensor(
+  ): Tensor[D] = fromNative(
     torchNative.bilinear(input1.native, input2.native, weight.native, toOptional(bias))
   )
 

--- a/core/src/main/scala/torch/nn/functional/Loss.scala
+++ b/core/src/main/scala/torch/nn/functional/Loss.scala
@@ -20,10 +20,9 @@ package functional
 
 import org.bytedeco.javacpp.LongPointer
 import org.bytedeco.pytorch
-import org.bytedeco.pytorch.TensorOptional
+import org.bytedeco.pytorch.{BCEWithLogitsLossOptions, TensorOptional}
 import org.bytedeco.pytorch.global.torch as torchNative
-import torch.internal.NativeConverters.toOptional
-import org.bytedeco.pytorch.BCEWithLogitsLossOptions
+import torch.internal.NativeConverters.{fromNative, toOptional}
 
 // Loss functions
 private[torch] trait Loss {
@@ -41,7 +40,7 @@ private[torch] trait Loss {
       input: Tensor[I],
       target: Tensor[O]
   ): Tensor[O] =
-    Tensor(
+    fromNative(
       torchNative.binary_cross_entropy_with_logits(
         input.native,
         target.native,

--- a/core/src/main/scala/torch/nn/functional/Pooling.scala
+++ b/core/src/main/scala/torch/nn/functional/Pooling.scala
@@ -79,7 +79,7 @@ private[torch] trait Pooling {
     options.padding().put(toNative(padding))
     options.ceil_mode().put(ceilMode)
     options.count_include_pad().put(countIncludePad)
-    Tensor(torchNative.avg_pool1d(input.native, options))
+    fromNative(torchNative.avg_pool1d(input.native, options))
 
   /** Applies a 2D max pooling over an input signal composed of several input planes.
     *
@@ -104,7 +104,7 @@ private[torch] trait Pooling {
     divisor_override match
       case d: Int => options.divisor_override().put(d)
       case None   =>
-    Tensor(torchNative.avg_pool2d(input.native, options))
+    fromNative(torchNative.avg_pool2d(input.native, options))
 
   /** Applies a 3D max pooling over an input signal composed of several input planes.
     *
@@ -129,7 +129,7 @@ private[torch] trait Pooling {
     divisor_override match
       case d: Int => options.divisor_override().put(d)
       case None   =>
-    Tensor(torchNative.avg_pool3d(input.native, options))
+    fromNative(torchNative.avg_pool3d(input.native, options))
 
   private def maxPool1dOptions[D <: FloatNN | Complex32](
       kernelSize: Int | (Int, Int),
@@ -175,7 +175,7 @@ private[torch] trait Pooling {
   ): Tensor[D] =
     val options: MaxPool1dOptions =
       maxPool1dOptions(kernelSize, stride, padding, dilation, ceilMode)
-    Tensor(torchNative.max_pool1d(input.native, options))
+    fromNative(torchNative.max_pool1d(input.native, options))
 
   /** Applies a 1D max pooling over an input signal composed of several input planes.
     *
@@ -206,7 +206,7 @@ private[torch] trait Pooling {
     val options: MaxPool1dOptions =
       maxPool1dOptions(kernelSize, stride, padding, dilation, ceilMode)
     val native = torchNative.max_pool1d_with_indices(input.native, options)
-    TensorTuple(values = Tensor[D](native.get0()), indices = Tensor(native.get1))
+    TensorTuple(values = fromNative[D](native.get0()), indices = fromNative(native.get1))
 
   private def maxPool2dOptions[D <: FloatNN | Complex32](
       kernelSize: Int | (Int, Int),
@@ -255,7 +255,7 @@ private[torch] trait Pooling {
   ): Tensor[D] =
     val options: MaxPool2dOptions =
       maxPool2dOptions(kernelSize, stride, padding, dilation, ceilMode)
-    Tensor(torchNative.max_pool2d(input.native, options))
+    fromNative(torchNative.max_pool2d(input.native, options))
 
   /** Applies a 2D max pooling over an input signal composed of several input planes.
     *
@@ -288,7 +288,7 @@ private[torch] trait Pooling {
     val options: MaxPool2dOptions =
       maxPool2dOptions(kernelSize, stride, padding, dilation, ceilMode)
     val native = torchNative.max_pool2d_with_indices(input.native, options)
-    TensorTuple(values = Tensor[D](native.get0()), indices = Tensor(native.get1))
+    TensorTuple(values = fromNative[D](native.get0()), indices = fromNative(native.get1))
 
   private def maxPool3dOptions[D <: FloatNN | Complex32](
       kernelSize: Int | (Int, Int, Int),
@@ -321,7 +321,7 @@ private[torch] trait Pooling {
   ): Tensor[D] =
     val options: MaxPool3dOptions =
       maxPool3dOptions(kernelSize, stride, padding, dilation, ceilMode)
-    Tensor(torchNative.max_pool3d(input.native, options))
+    fromNative(torchNative.max_pool3d(input.native, options))
 
   /** Applies a 3D max pooling over an input signal composed of several input planes.
     *
@@ -338,7 +338,7 @@ private[torch] trait Pooling {
     val options: MaxPool3dOptions =
       maxPool3dOptions(kernelSize, stride, padding, dilation, ceilMode)
     val native = torchNative.max_pool3d_with_indices(input.native, options)
-    TensorTuple(values = Tensor[D](native.get0()), indices = Tensor(native.get1))
+    TensorTuple(values = fromNative[D](native.get0()), indices = fromNative(native.get1))
 
   // TODO max_unpool1d Computes a partial inverse of MaxPool1d.
   // TODO max_unpool2d Computes a partial inverse of MaxPool2d.

--- a/core/src/main/scala/torch/nn/functional/Sparse.scala
+++ b/core/src/main/scala/torch/nn/functional/Sparse.scala
@@ -19,6 +19,7 @@ package nn
 package functional
 
 import org.bytedeco.pytorch.global.torch as torchNative
+import torch.internal.NativeConverters.fromNative
 
 private[torch] trait Sparse {
 
@@ -29,5 +30,5 @@ private[torch] trait Sparse {
     * @group nn_sparse
     */
   def oneHot(input: Tensor[Int64], numClasses: Long = -1): Tensor[Int64] =
-    Tensor(torchNative.one_hot(input.native, numClasses))
+    fromNative(torchNative.one_hot(input.native, numClasses))
 }

--- a/core/src/main/scala/torch/nn/loss/CrossEntropyLoss.scala
+++ b/core/src/main/scala/torch/nn/loss/CrossEntropyLoss.scala
@@ -20,14 +20,14 @@ package loss
 
 import org.bytedeco.pytorch.CrossEntropyLossImpl
 import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** This criterion computes the cross entropy loss between input and target. */
 // TODO optional args
 final class CrossEntropyLoss extends Module {
   override private[torch] val nativeModule: CrossEntropyLossImpl = CrossEntropyLossImpl()
 
-  def apply[D <: DType](input: Tensor[D], target: Tensor[?]): Tensor[D] = Tensor(
+  def apply[D <: DType](input: Tensor[D], target: Tensor[?]): Tensor[D] = fromNative(
     nativeModule.forward(input.native, target.native)
   )
 }

--- a/core/src/main/scala/torch/nn/modules/activation/LogSoftmax.scala
+++ b/core/src/main/scala/torch/nn/modules/activation/LogSoftmax.scala
@@ -21,8 +21,7 @@ package activation
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.LogSoftmaxImpl
-import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies the log(Softmax(x)) function to an n-dimensional input Tensor. The LogSoftmax
   * formulation can be simplified as:
@@ -41,4 +40,4 @@ import torch.{DType, Tensor}
 final class LogSoftmax[D <: DType: Default](dim: Int) extends TensorModule[D]:
   override val nativeModule: LogSoftmaxImpl = LogSoftmaxImpl(dim)
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))

--- a/core/src/main/scala/torch/nn/modules/activation/ReLU.scala
+++ b/core/src/main/scala/torch/nn/modules/activation/ReLU.scala
@@ -21,8 +21,7 @@ package activation
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{ReLUImpl, ReLUOptions}
-import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies the rectified linear unit function element-wise:
   *
@@ -34,6 +33,6 @@ final class ReLU[D <: DType: Default](inplace: Boolean = false) extends TensorMo
 
   override protected[torch] val nativeModule: ReLUImpl = ReLUImpl()
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))
 
   override def toString = getClass().getSimpleName()

--- a/core/src/main/scala/torch/nn/modules/activation/Softmax.scala
+++ b/core/src/main/scala/torch/nn/modules/activation/Softmax.scala
@@ -21,8 +21,7 @@ package activation
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.SoftmaxImpl
-import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies the Softmax function to an n-dimensional input Tensor rescaling them so that the
   * elements of the n-dimensional output Tensor lie in the range [0,1] and sum to 1.
@@ -34,4 +33,4 @@ import torch.{DType, Tensor}
 final class Softmax[D <: DType: Default](dim: Int) extends TensorModule[D]:
   override val nativeModule: SoftmaxImpl = SoftmaxImpl(dim)
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))

--- a/core/src/main/scala/torch/nn/modules/activation/Tanh.scala
+++ b/core/src/main/scala/torch/nn/modules/activation/Tanh.scala
@@ -19,10 +19,8 @@ package nn
 package modules
 package activation
 
-import org.bytedeco.pytorch
 import org.bytedeco.pytorch.TanhImpl
-import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies the Hyperbolic Tangent (Tanh) function element-wise. Tanh is defined as::
   *
@@ -41,6 +39,6 @@ final class Tanh[D <: DType: Default] extends TensorModule[D]:
 
   override protected[torch] val nativeModule: TanhImpl = new TanhImpl()
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))
 
   override def toString = getClass().getSimpleName()

--- a/core/src/main/scala/torch/nn/modules/batchnorm/BatchNorm1d.scala
+++ b/core/src/main/scala/torch/nn/modules/batchnorm/BatchNorm1d.scala
@@ -20,11 +20,10 @@ package modules
 package batchnorm
 
 import org.bytedeco.javacpp.LongPointer
+import org.bytedeco.pytorch.{BatchNorm1dImpl, BatchNormOptions}
 import org.bytedeco.pytorch
 import sourcecode.Name
-import org.bytedeco.pytorch.BatchNorm1dImpl
-import org.bytedeco.pytorch.BatchNormOptions
-import torch.nn.modules.{HasParams, HasWeight, TensorModule}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies Batch Normalization over a 2D or 3D input as described in the paper [Batch
   * Normalization: Accelerating Deep Network Training by Reducing Internal Covariate
@@ -114,10 +113,10 @@ final class BatchNorm1d[ParamType <: FloatNN | ComplexNN: Default](
   nativeModule.to(paramType.toScalarType, false)
 
   // TODO weight, bias etc. are undefined if affine = false. We need to take that into account
-  val weight: Tensor[ParamType] = Tensor[ParamType](nativeModule.weight)
-  val bias: Tensor[ParamType] = Tensor[ParamType](nativeModule.bias)
+  val weight: Tensor[ParamType] = fromNative[ParamType](nativeModule.weight)
+  val bias: Tensor[ParamType] = fromNative[ParamType](nativeModule.bias)
   // TODO running_mean, running_var, num_batches_tracked
 
-  def apply(t: Tensor[ParamType]): Tensor[ParamType] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[ParamType]): Tensor[ParamType] = fromNative(nativeModule.forward(t.native))
 
   override def toString(): String = s"${getClass().getSimpleName()}(numFeatures=$numFeatures)"

--- a/core/src/main/scala/torch/nn/modules/batchnorm/BatchNorm2d.scala
+++ b/core/src/main/scala/torch/nn/modules/batchnorm/BatchNorm2d.scala
@@ -20,11 +20,10 @@ package modules
 package batchnorm
 
 import org.bytedeco.javacpp.LongPointer
+import org.bytedeco.pytorch.{BatchNorm2dImpl, BatchNormOptions}
 import org.bytedeco.pytorch
 import sourcecode.Name
-import org.bytedeco.pytorch.BatchNorm2dImpl
-import org.bytedeco.pytorch.BatchNormOptions
-import torch.nn.modules.{HasParams, HasWeight}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies Batch Normalization over a 4D input as described in the paper [Batch Normalization:
   * Accelerating Deep Network Training by Reducing Internal Covariate
@@ -111,10 +110,10 @@ final class BatchNorm2d[ParamType <: FloatNN | ComplexNN: Default](
   nativeModule.to(paramType.toScalarType, false)
 
   // TODO weight, bias etc. are undefined if affine = false. We need to take that into account
-  val weight: Tensor[ParamType] = Tensor[ParamType](nativeModule.weight)
-  val bias: Tensor[ParamType] = Tensor[ParamType](nativeModule.bias)
+  val weight: Tensor[ParamType] = fromNative[ParamType](nativeModule.weight)
+  val bias: Tensor[ParamType] = fromNative[ParamType](nativeModule.bias)
   // TODO running_mean, running_var, num_batches_tracked
 
-  def apply(t: Tensor[ParamType]): Tensor[ParamType] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[ParamType]): Tensor[ParamType] = fromNative(nativeModule.forward(t.native))
 
   override def toString(): String = s"${getClass().getSimpleName()}(numFeatures=$numFeatures)"

--- a/core/src/main/scala/torch/nn/modules/conv/Conv2d.scala
+++ b/core/src/main/scala/torch/nn/modules/conv/Conv2d.scala
@@ -21,12 +21,10 @@ package conv
 
 import org.bytedeco.javacpp.LongPointer
 import org.bytedeco.pytorch
-import org.bytedeco.pytorch.*
+import org.bytedeco.pytorch.{Conv2dImpl, Conv2dOptions, kZeros, kReflect, kReplicate, kCircular}
 import sourcecode.Name
-import torch.Tensor
-import torch.internal.NativeConverters.toNative
+import torch.internal.NativeConverters.{fromNative, toNative}
 import torch.nn.modules.conv.Conv2d.PaddingMode
-import torch.nn.modules.{HasParams}
 
 /** Applies a 2D convolution over an input signal composed of several input planes.
   *
@@ -61,9 +59,9 @@ final class Conv2d[ParamType <: FloatNN | ComplexNN: Default](
   override private[torch] val nativeModule: Conv2dImpl = Conv2dImpl(options)
   nativeModule.to(paramType.toScalarType, false)
 
-  def apply(t: Tensor[ParamType]): Tensor[ParamType] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[ParamType]): Tensor[ParamType] = fromNative(nativeModule.forward(t.native))
 
-  val weight = Tensor[ParamType](nativeModule.weight)
+  def weight: Tensor[ParamType] = fromNative(nativeModule.weight)
 
   override def toString =
     s"Conv2d($inChannels, $outChannels, kernelSize=$kernelSize, stride=$stride, padding=$padding, bias=$bias)"

--- a/core/src/main/scala/torch/nn/modules/flatten/Flatten.scala
+++ b/core/src/main/scala/torch/nn/modules/flatten/Flatten.scala
@@ -21,6 +21,7 @@ package flatten
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{FlattenImpl, FlattenOptions}
+import torch.internal.NativeConverters.fromNative
 
 // format: off
 /** Flattens a contiguous range of dims into a tensor. For use with [[nn.Sequential]].
@@ -59,6 +60,6 @@ final class Flatten[D <: DType: Default](startDim: Int = 1, endDim: Int = -1)
 
   override val nativeModule: FlattenImpl = FlattenImpl(options)
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))
 
   override def toString = getClass().getSimpleName()

--- a/core/src/main/scala/torch/nn/modules/linear/Identity.scala
+++ b/core/src/main/scala/torch/nn/modules/linear/Identity.scala
@@ -21,8 +21,7 @@ package linear
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.IdentityImpl
-import torch.nn.modules.Module
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** A placeholder identity operator that is argument-insensitive.
   *
@@ -31,4 +30,4 @@ import torch.{DType, Tensor}
 final class Identity[D <: DType: Default](args: Any*) extends TensorModule[D]:
   override val nativeModule: IdentityImpl = IdentityImpl()
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))

--- a/core/src/main/scala/torch/nn/modules/linear/Linear.scala
+++ b/core/src/main/scala/torch/nn/modules/linear/Linear.scala
@@ -21,8 +21,8 @@ package linear
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{LinearImpl, LinearOptions}
-import torch.Tensor
 import torch.nn.modules.{HasParams}
+import internal.NativeConverters.fromNative
 
 /** Applies a linear transformation to the incoming data: $y = xA^T + b$
   *
@@ -59,13 +59,13 @@ final class Linear[ParamType <: FloatNN: Default](
   override private[torch] val nativeModule: LinearImpl = new LinearImpl(options)
   nativeModule.to(paramType.toScalarType, false)
 
-  def weight = Tensor[ParamType](nativeModule.weight())
+  def weight = fromNative[ParamType](nativeModule.weight())
   def weight_=(t: Tensor[ParamType]): Unit = nativeModule.weight(t.native)
 
-  def bias = Tensor[ParamType](nativeModule.bias())
+  def bias = fromNative[ParamType](nativeModule.bias())
   def bias_=(t: Tensor[ParamType]): Unit = nativeModule.bias(t.native)
 
-  def apply(input: Tensor[ParamType]): Tensor[ParamType] = Tensor(
+  def apply(input: Tensor[ParamType]): Tensor[ParamType] = fromNative(
     nativeModule.forward(input.native)
   )
 

--- a/core/src/main/scala/torch/nn/modules/normalization/GroupNorm.scala
+++ b/core/src/main/scala/torch/nn/modules/normalization/GroupNorm.scala
@@ -21,7 +21,7 @@ package normalization
 
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{GroupNormImpl, GroupNormOptions}
-import torch.{DType, Tensor}
+import torch.internal.NativeConverters.fromNative
 
 /** Applies Group Normalization over a mini-batch of inputs
   *
@@ -48,8 +48,8 @@ final class GroupNorm[ParamType <: FloatNN | ComplexNN: Default](
 
   override private[torch] val nativeModule: GroupNormImpl = GroupNormImpl(options)
 
-  val weight: Tensor[ParamType] = Tensor[ParamType](nativeModule.weight)
-  val bias: Tensor[ParamType] = Tensor[ParamType](nativeModule.bias)
+  val weight: Tensor[ParamType] = fromNative[ParamType](nativeModule.weight)
+  val bias: Tensor[ParamType] = fromNative[ParamType](nativeModule.bias)
 
   def apply(t: Tensor[ParamType]): Tensor[ParamType] =
-    Tensor[ParamType](nativeModule.forward(t.native))
+    fromNative[ParamType](nativeModule.forward(t.native))

--- a/core/src/main/scala/torch/nn/modules/normalization/LayerNorm.scala
+++ b/core/src/main/scala/torch/nn/modules/normalization/LayerNorm.scala
@@ -22,7 +22,7 @@ package normalization
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{LayerNormImpl, LayerNormOptions, LongVector}
 import torch.nn.modules.TensorModule
-import torch.{DType, Tensor}
+import internal.NativeConverters.fromNative
 
 /** Applies Layer Normalization over a mini-batch of inputs as described in the paper Layer
   * Normalization // TODO Add docs
@@ -43,8 +43,8 @@ final class LayerNorm[ParamType <: DType: Default](
 
   override private[torch] val nativeModule: LayerNormImpl = LayerNormImpl(options)
 
-  val weight: Tensor[ParamType] = Tensor[ParamType](nativeModule.weight)
-  val bias: Tensor[ParamType] = Tensor[ParamType](nativeModule.bias)
+  val weight: Tensor[ParamType] = fromNative[ParamType](nativeModule.weight)
+  val bias: Tensor[ParamType] = fromNative[ParamType](nativeModule.bias)
 
   def apply(t: Tensor[ParamType]): Tensor[ParamType] =
-    Tensor[ParamType](nativeModule.forward(t.native))
+    fromNative[ParamType](nativeModule.forward(t.native))

--- a/core/src/main/scala/torch/nn/modules/pooling/AdaptiveAvgPool2d.scala
+++ b/core/src/main/scala/torch/nn/modules/pooling/AdaptiveAvgPool2d.scala
@@ -23,7 +23,7 @@ import org.bytedeco.pytorch.AdaptiveAvgPool2dImpl
 import org.bytedeco.javacpp.LongPointer
 import org.bytedeco.pytorch
 
-import torch.internal.NativeConverters.{toNative, toOptional}
+import torch.internal.NativeConverters.{fromNative, toNative, toOptional}
 import org.bytedeco.pytorch.LongOptionalVector
 import org.bytedeco.pytorch.LongOptional
 
@@ -49,7 +49,7 @@ final class AdaptiveAvgPool2d[D <: BFloat16 | Float32 | Float64: Default](
     nativeOutputSize.get(0)
   )
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(
     nativeModule.forward(t.native)
   )
 }

--- a/core/src/main/scala/torch/nn/modules/pooling/MaxPool2d.scala
+++ b/core/src/main/scala/torch/nn/modules/pooling/MaxPool2d.scala
@@ -22,9 +22,7 @@ package pooling
 import org.bytedeco.javacpp.LongPointer
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{MaxPool2dImpl, MaxPool2dOptions}
-import torch.internal.NativeConverters.toNative
-import torch.nn.modules.{HasParams}
-import torch.{BFloat16, Float32, Float64, Tensor}
+import torch.internal.NativeConverters.{fromNative, toNative}
 
 /** Applies a 2D max pooling over an input signal composed of several input planes. */
 final class MaxPool2d[D <: BFloat16 | Float32 | Float64: Default](
@@ -47,5 +45,5 @@ final class MaxPool2d[D <: BFloat16 | Float32 | Float64: Default](
   override def toString(): String =
     s"MaxPool2d(kernelSize=$kernelSize, stride=$stride, padding=$padding, dilation=$dilation, ceilMode=$ceilMode)"
 
-  def apply(t: Tensor[D]): Tensor[D] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[D]): Tensor[D] = fromNative(nativeModule.forward(t.native))
   // TODO forward_with_indices

--- a/core/src/main/scala/torch/nn/modules/sparse/Embedding.scala
+++ b/core/src/main/scala/torch/nn/modules/sparse/Embedding.scala
@@ -25,7 +25,7 @@ import sourcecode.Name
 import org.bytedeco.pytorch.EmbeddingImpl
 import org.bytedeco.pytorch.EmbeddingOptions
 import torch.nn.modules.{HasParams, HasWeight, TensorModule}
-import torch.internal.NativeConverters.{toNative, doubleToDoublePointer}
+import torch.internal.NativeConverters.{fromNative, toNative, doubleToDoublePointer}
 
 /** A simple lookup table that stores embeddings of a fixed dictionary and size.
   *
@@ -77,9 +77,9 @@ final class Embedding[ParamType <: FloatNN | ComplexNN: Default](
   override val nativeModule: EmbeddingImpl = EmbeddingImpl(options)
   nativeModule.to(paramType.toScalarType, false)
 
-  def weight: Tensor[ParamType] = Tensor[ParamType](nativeModule.weight)
+  def weight: Tensor[ParamType] = fromNative(nativeModule.weight)
   def weight_=(w: Tensor[ParamType]): Unit = nativeModule.weight(w.native)
 
-  def apply(t: Tensor[Int64]): Tensor[ParamType] = Tensor(nativeModule.forward(t.native))
+  def apply(t: Tensor[Int64]): Tensor[ParamType] = fromNative(nativeModule.forward(t.native))
 
   override def toString(): String = s"${getClass().getSimpleName()}(numEmbeddings=$numEmbeddings)"

--- a/core/src/main/scala/torch/ops/ComparisonOps.scala
+++ b/core/src/main/scala/torch/ops/ComparisonOps.scala
@@ -18,6 +18,7 @@ package torch
 package ops
 
 import org.bytedeco.pytorch.global.torch as torchNative
+import internal.NativeConverters.fromNative
 
 /** Comparison Ops
   *
@@ -74,7 +75,7 @@ private[torch] trait ComparisonOps {
       // TODO implement stable, there are two boolean args in argsort and are not in order
       // stable: Boolean = false
   ): Tensor[Int64] =
-    Tensor(
+    fromNative(
       torchNative.argsort(input.native, dim.toLong, descending)
     )
 }

--- a/core/src/main/scala/torch/ops/CreationOps.scala
+++ b/core/src/main/scala/torch/ops/CreationOps.scala
@@ -29,6 +29,7 @@ import org.bytedeco.pytorch.global.torch as torchNative
 
 import java.nio.file.{Files, Path}
 import scala.collection.immutable.{VectorMap, SeqMap}
+import Tensor.fromNative
 
 /** Creation Ops
   *
@@ -64,7 +65,7 @@ private[torch] trait CreationOps {
     val nativeSize = size match
       case s: Seq[Int] => s.map(_.toLong).toArray
       case s: Int      => Array(s.toLong)
-    Tensor(
+    fromNative(
       torchNative.torch_zeros(
         nativeSize,
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)
@@ -100,7 +101,7 @@ private[torch] trait CreationOps {
     val nativeSize = size match
       case s: Seq[Int] => s.map(_.toLong).toArray
       case s: Int      => Array(s.toLong)
-    Tensor(
+    fromNative(
       torchNative.torch_ones(
         nativeSize,
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)
@@ -151,7 +152,7 @@ private[torch] trait CreationOps {
     val derivedDType = dtype match
       case _: Derive => derivedArangeType(start, end, step)
       case t: DType  => t
-    Tensor(
+    fromNative(
       torchNative.torch_arange(
         toScalar(start),
         toScalar(end),
@@ -170,7 +171,7 @@ private[torch] trait CreationOps {
       device: Device = CPU,
       requiresGrad: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_linspace(
         new Scalar(start),
         new Scalar(end),
@@ -189,7 +190,7 @@ private[torch] trait CreationOps {
       layout: Layout = Strided,
       device: Device = CPU,
       requiresGrad: Boolean = false
-  ) = Tensor(
+  ) = fromNative(
     torchNative.torch_logspace(
       new Scalar(start),
       new Scalar(end),
@@ -223,10 +224,10 @@ private[torch] trait CreationOps {
       layout: Layout = Strided,
       device: Device = CPU,
       requiresGrad: Boolean = false
-  ): Tensor[D] = Tensor(
+  ): Tensor[D] = fromNative(
     torchNative.torch_eye(n, NativeConverters.tensorOptions(dtype, layout, device, requiresGrad))
   )
-// def empty(size: Long*): Tensor[D] = Tensor(torchNative.torch_empty(size*))
+// def empty(size: Long*): Tensor[D] = fromNative(torchNative.torch_empty(size*))
 
   /** Returns a tensor filled with uninitialized data.
     *
@@ -241,7 +242,7 @@ private[torch] trait CreationOps {
       pinMemory: Boolean = false,
       memoryFormat: MemoryFormat = Contiguous
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_empty(
         size.toArray.map(_.toLong),
         NativeConverters
@@ -306,7 +307,7 @@ private[torch] trait CreationOps {
     val derivedDType = dtype match
       case _: Derive => scalaToDType(fillValue)
       case t: DType  => t
-    Tensor(
+    fromNative(
       torchNative.torch_full(
         size.toArray.map(_.toLong),
         toScalar(fillValue),
@@ -332,7 +333,7 @@ private[torch] trait CreationOps {
       nativeIt.increment()
     VectorMap.from(buffer.map { (key, value) =>
       // TODO better error handling
-      (key.toStringRef().getString(), Tensor[DType](value.toTensor().clone()))
+      (key.toStringRef().getString(), fromNative[DType](value.toTensor().clone()))
     })
 
   def pickleLoad(path: Path): Map[String, Tensor[DType]] =

--- a/core/src/main/scala/torch/ops/IndexingSlicingJoiningOps.scala
+++ b/core/src/main/scala/torch/ops/IndexingSlicingJoiningOps.scala
@@ -65,7 +65,9 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def adjoint[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.adjoint(input.native))
+  def adjoint[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(
+    torchNative.adjoint(input.native)
+  )
 
   /** Returns a tensor containing the indices of all non-zero elements of `input`. Each row in the
     * result contains the indices of a non-zero element in `input`. The result is sorted
@@ -87,7 +89,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def argwhere[D <: DType](input: Tensor[D]): Tensor[Int64] = Tensor(
+  def argwhere[D <: DType](input: Tensor[D]): Tensor[Int64] = fromNative(
     torchNative.argwhere(input.native)
   )
 
@@ -123,7 +125,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def cat[D <: DType](tensors: Seq[Tensor[D]], dim: Int = 0): Tensor[D] = Tensor(
+  def cat[D <: DType](tensors: Seq[Tensor[D]], dim: Int = 0): Tensor[D] = fromNative(
     torchNative.cat(toArrayRef(tensors), dim.toLong)
   )
 
@@ -161,7 +163,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def conj[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.conj(input.native))
+  def conj[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(torchNative.conj(input.native))
 
   /** Attempts to split a tensor into the specified number of chunks. Each chunk is a view of the
     * input tensor.
@@ -227,7 +229,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
   def chunk[D <: DType](input: Tensor[D], chunks: Int, dim: Int = 0): Seq[Tensor[D]] = {
     val tensors = torchNative.chunk(input.native, chunks, dim.toLong)
-    (0L until tensors.size()).map(i => Tensor(tensors.get(i)))
+    (0L until tensors.size()).map(i => fromNative(tensors.get(i)))
   }
 
   /** Splits `input`, a tensor with three or more dimensions, into multiple tensors depthwise
@@ -265,7 +267,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
   def dsplit[D <: DType](input: Tensor[D], indicesOrSections: Int*): Seq[Tensor[D]] = {
     val tensors = torchNative.dsplit(input.native, indicesOrSections.map(_.toLong)*)
-    (0L until tensors.size()).map(i => Tensor(tensors.get(i)))
+    (0L until tensors.size()).map(i => fromNative(tensors.get(i)))
   }
 
   /** Creates a new tensor by horizontally stacking the tensors in `tensors`.
@@ -297,7 +299,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def columnStack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] =
-    Tensor(torchNative.column_stack(toArrayRef(tensors)))
+    fromNative(torchNative.column_stack(toArrayRef(tensors)))
 
   /** Stack tensors in sequence depthwise (along third axis).
     *
@@ -325,7 +327,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def dstack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] = Tensor(
+  def dstack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] = fromNative(
     torchNative.dstack(toArrayRef(tensors))
   )
 
@@ -369,7 +371,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       sparseGrad: Boolean = false
   ): Tensor[D] =
-    Tensor(torchNative.gather(input.native, dim.toLong, index.native, sparseGrad))
+    fromNative(torchNative.gather(input.native, dim.toLong, index.native, sparseGrad))
 
   /** Splits `input`, a tensor with one or more dimensions, into multiple tensors horizontally
     * according to `indices_or_sections`. Each split is a view of `input`.
@@ -403,7 +405,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
   def hsplit[D <: DType](input: Tensor[D], indicesOrSections: Int*): Seq[Tensor[D]] = {
     val tensors = torchNative.hsplit(input.native, indicesOrSections.toArray.map(_.toLong)*)
-    (0L until tensors.size()).map(i => Tensor(tensors.get(i)))
+    (0L until tensors.size()).map(i => fromNative(tensors.get(i)))
   }
 
   /** Stack tensors in sequence horizontally (column wise).
@@ -431,7 +433,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def hstack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] =
-    Tensor(torchNative.hstack(toArrayRef(tensors)))
+    fromNative(torchNative.hstack(toArrayRef(tensors)))
 
   /** Accumulate the elements of `source` into the `input` tensor by adding to the indices in the
     * order given in `index`.
@@ -467,7 +469,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       source: Tensor[D]
   ): Tensor[D] =
-    Tensor(torchNative.index_add(input.native, dim.toLong, index.native, source.native))
+    fromNative(torchNative.index_add(input.native, dim.toLong, index.native, source.native))
 
   /** Copies the elements of tensor into the self tensor by selecting the indices in the order given
     * in index. For example, if dim == 0 and index[i] == j, then the ith row of tensor is copied to
@@ -507,7 +509,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       source: Tensor[D]
   ): Tensor[D] =
-    Tensor(torchNative.index_copy(input.native, dim.toLong, index.native, source.native))
+    fromNative(torchNative.index_copy(input.native, dim.toLong, index.native, source.native))
 
   // TODO index_reduce
   // TODO Enum for reduce: String
@@ -544,7 +546,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def indexSelect[D <: DType](input: Tensor[D], dim: Int, index: Tensor[Int64]): Tensor[D] =
-    Tensor(torchNative.index_select(input.native, dim.toLong, index.native))
+    fromNative(torchNative.index_select(input.native, dim.toLong, index.native))
 
   /** Returns a new 1-D tensor which indexes the `input` tensor according to the boolean mask `mask`
     * which is a <span class="title-ref">BoolTensor</span>.
@@ -575,7 +577,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def maskedSelect[D <: DType](input: Tensor[D], mask: Tensor[Bool]): Tensor[D] =
-    Tensor(torchNative.masked_select(input.native, mask.native))
+    fromNative(torchNative.masked_select(input.native, mask.native))
 
   /** Moves the dimension(s) of `input` at the position(s) in `source` to the position(s) in
     * `destination`.
@@ -624,9 +626,9 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def movedim[D <: DType](input: Tensor[D], source: Int, destination: Int): Tensor[D] =
-    Tensor(torchNative.movedim(input.native, source.toLong, destination.toLong))
+    fromNative(torchNative.movedim(input.native, source.toLong, destination.toLong))
   def movedim[D <: DType](input: Tensor[D], source: Seq[Int], destination: Seq[Int]): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.movedim(input.native, source.map(_.toLong).toArray, destination.map(_.toLong)*)
     )
 
@@ -674,9 +676,9 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
 
   def moveaxis[D <: DType](input: Tensor[D], source: Int, destination: Int): Tensor[D] =
-    Tensor(torchNative.moveaxis(input.native, source.toLong, destination.toLong))
+    fromNative(torchNative.moveaxis(input.native, source.toLong, destination.toLong))
   def moveaxis[D <: DType](input: Tensor[D], source: Seq[Int], destination: Seq[Int]): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.moveaxis(input.native, source.map(_.toLong).toArray, destination.map(_.toLong)*)
     )
 
@@ -729,7 +731,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       * @group indexing_slicing_joining_mutating_ops
       */
   def narrow[D <: DType](input: Tensor[D], dim: Int, start: Int, length: Int): Tensor[D] =
-    Tensor(torchNative.narrow(input.native, dim.toLong, start.toLong, length.toLong))
+    fromNative(torchNative.narrow(input.native, dim.toLong, start.toLong, length.toLong))
 
   /** Same as `torch.narrow` except this returns a copy rather than shared storage. This is
     * primarily for sparse tensors, which do not have a shared-storage narrow method.
@@ -774,7 +776,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def narrowCopy[D <: DType](input: Tensor[D], dim: Int, start: Int, length: Int): Tensor[D] =
-    Tensor(torchNative.narrow_copy(input.native, dim.toLong, start.toLong, length.toLong))
+    fromNative(torchNative.narrow_copy(input.native, dim.toLong, start.toLong, length.toLong))
 
   /** Returns a tensor containing the indices of all non-zero elements of `input`. Each row in the
     * result contains the indices of a non-zero element in `input`. The result is sorted
@@ -812,7 +814,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def nonzero[D <: DType](input: Tensor[D]): Tensor[Int64] = Tensor(
+  def nonzero[D <: DType](input: Tensor[D]): Tensor[Int64] = fromNative(
     torchNative.nonzero(input.native)
   )
 
@@ -836,7 +838,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   The desired ordering of dimensions, must be unique
     */
   def permute[D <: DType](input: Tensor[D], dims: Int*): Tensor[D] =
-    Tensor(torchNative.permute(input.native, dims.map(_.toLong)*))
+    fromNative(torchNative.permute(input.native, dims.map(_.toLong)*))
 
   /** Returns a tensor with the same data and number of elements as `input`, but with the specified
     * shape. When possible, the returned tensor will be a view of `input`. Otherwise, it will be a
@@ -868,7 +870,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def reshape[D <: DType](input: Tensor[D], shape: Int*): Tensor[D] =
-    Tensor(torchNative.reshape(input.native, shape.map(_.toLong)*))
+    fromNative(torchNative.reshape(input.native, shape.map(_.toLong)*))
 
   /** Slices the `input` tensor along the selected dimension at the given index. This function
     * returns a view of the original tensor with the given dimension removed.
@@ -889,7 +891,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   the index to select with
     */
   def select[D <: DType](input: Tensor[D], dim: Int, index: Int): Tensor[D] =
-    Tensor(torchNative.select(input.native, dim.toLong, index.toLong))
+    fromNative(torchNative.select(input.native, dim.toLong, index.toLong))
 
   // TODO Add docs for scatter
   // TODO Add reduction arg
@@ -899,7 +901,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       source: Tensor[D]
   ): Tensor[D] =
-    Tensor(torchNative.scatter(input.native, dim.toLong, index.native, source.native))
+    fromNative(torchNative.scatter(input.native, dim.toLong, index.native, source.native))
 
   // TODO Add docs diagonalScatter
   def diagonalScatter[D <: DType](
@@ -909,7 +911,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       dim1: Int = 0,
       dim2: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.diagonal_scatter(
         input.native,
         src.native,
@@ -921,7 +923,7 @@ private[torch] trait IndexingSlicingJoiningOps {
 
   // TODO Add docs selectScatter
   def selectScatter[D <: DType](input: Tensor[D], src: Tensor[D], dim: Int, index: Int): Tensor[D] =
-    Tensor(torchNative.select_scatter(input.native, src.native, dim.toLong, index.toLong))
+    fromNative(torchNative.select_scatter(input.native, src.native, dim.toLong, index.toLong))
 
   // TODO Add docs for sliceScatterd
   // TODO Review default start and end
@@ -933,7 +935,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       end: Int | Option[Int] = None,
       step: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.slice_scatter(
         input.native,
         src.native,
@@ -951,12 +953,12 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       src: Tensor[D]
   ): Tensor[D] =
-    Tensor(torchNative.scatter_add(input.native, dim.toLong, index.native, src.native))
+    fromNative(torchNative.scatter_add(input.native, dim.toLong, index.native, src.native))
 
   // TODO scatter_reduce
   // TODO enum for reduce options?
   // def scatterReduce[D <: DType](input: Tensor[D], dim: Int, index: Tensor[Int64], src: Tensor[D], reduce: String, includeSelf: Boolean): Tensor[D] =
-  //   Tensor(torchNative.scatter_reduce(input.native, dim.toLong, index.native, src.native, reduce))
+  //   fromNative(torchNative.scatter_reduce(input.native, dim.toLong, index.native, src.native, reduce))
 
   /** Splits the tensor into chunks. Each chunk is a view of the original tensor.
     *
@@ -1016,7 +1018,7 @@ private[torch] trait IndexingSlicingJoiningOps {
         case i: Int      => torchNative.split(input.native, i.toLong, dim.toLong)
         case s: Seq[Int] => torchNative.split(input.native, s.map(_.toLong).toArray, dim.toLong)
       }
-    (0L until result.size()).map(i => Tensor(result.get(i)))
+    (0L until result.size()).map(i => fromNative(result.get(i)))
   }
 
   /** Returns a tensor with all specified dimensions of `input` of size 1 removed.
@@ -1067,8 +1069,8 @@ private[torch] trait IndexingSlicingJoiningOps {
   def squeeze[D <: DType](input: Tensor[D], dim: Int*): Tensor[D] =
     // NOTE: There are different runtime behaviours betwen passing an empty dim and passing no dim, so we need to check for it
     dim match {
-      case Nil => Tensor(torchNative.squeeze(input.native))
-      case _   => Tensor(torchNative.squeeze(input.native, dim.map(_.toLong)*))
+      case Nil => fromNative(torchNative.squeeze(input.native))
+      case _   => fromNative(torchNative.squeeze(input.native, dim.map(_.toLong)*))
     }
 
   /** Concatenates a sequence of tensors along a new dimension.
@@ -1081,7 +1083,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   dimension to insert. Has to be between 0 and the number of dimensions of concatenated
     *   tensors (inclusive)
     */
-  def stack[D <: DType](tensors: Seq[Tensor[D]], dim: Int = 0): Tensor[D] = Tensor(
+  def stack[D <: DType](tensors: Seq[Tensor[D]], dim: Int = 0): Tensor[D] = fromNative(
     torchNative.stack(toArrayRef(tensors), dim)
   )
 
@@ -1120,7 +1122,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def swapaxes[D <: DType](input: Tensor[D], axis1: Int, axis2: Int): Tensor[D] =
-    Tensor(torchNative.swapaxes(input.native, axis1.toLong, axis2.toLong))
+    fromNative(torchNative.swapaxes(input.native, axis1.toLong, axis2.toLong))
 
   /** Alias for `torch.transpose`.
     *
@@ -1157,7 +1159,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def swapdims[D <: DType](input: Tensor[D], axis1: Int, axis2: Int): Tensor[D] =
-    Tensor(torchNative.swapdims(input.native, axis1.toLong, axis2.toLong))
+    fromNative(torchNative.swapdims(input.native, axis1.toLong, axis2.toLong))
 
   /** Expects `input` to be <= 2-D tensor and transposes dimensions 0 and 1.
     *
@@ -1180,7 +1182,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def t[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.t(input.native))
+  def t[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(torchNative.t(input.native))
 
   /** Returns a new tensor with the elements of `input` at the given indices. The input tensor is
     * treated as if it were viewed as a 1-D tensor. The result takes the same shape as the indices.
@@ -1198,7 +1200,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def take[D <: DType](input: Tensor[D], index: Tensor[Int64]): Tensor[D] =
-    Tensor(torchNative.take(input.native, index.native))
+    fromNative(torchNative.take(input.native, index.native))
 
   /** Selects values from `input` at the 1-dimensional indices from `indices` along the given `dim`.
     *
@@ -1232,7 +1234,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       index: Tensor[Int64],
       dim: Int | Option[Int] = None
   ): Tensor[D] =
-    Tensor(torchNative.take_along_dim(input.native, index.native, dim.toOptional))
+    fromNative(torchNative.take_along_dim(input.native, index.native, dim.toOptional))
 
   /** Splits a tensor into multiple sub-tensors, all of which are views of `input`, along dimension
     * `dim` according to the indices or number of sections specified by `indices_or_sections`. This
@@ -1305,7 +1307,7 @@ private[torch] trait IndexingSlicingJoiningOps {
       case s: Seq[Int] =>
         torchNative.tensor_split(input.native, s.toArray.map(_.toLong), dim.toLong)
     }
-    (0L until result.size()).map(i => Tensor(result.get(i)))
+    (0L until result.size()).map(i => fromNative(result.get(i)))
   }
 
   /** Constructs a tensor by repeating the elements of `input`. The `dims` argument specifies the
@@ -1342,7 +1344,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   the number of repetitions per dimension.
     */
   def tile[D <: DType](input: Tensor[D], reps: Int*): Tensor[D] =
-    Tensor(torchNative.tile(input.native, reps.map(_.toLong)*))
+    fromNative(torchNative.tile(input.native, reps.map(_.toLong)*))
 
   /** Returns a tensor that is a transposed version of `input`. The given dimensions `dim0` and
     * `dim1` are swapped.
@@ -1384,7 +1386,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     * @group indexing_slicing_joining_mutating_ops
     */
   def transpose[D <: DType](input: Tensor[D], dim0: Int, dim1: Int): Tensor[D] =
-    Tensor(torchNative.transpose(input.native, dim0.toLong, dim1.toLong))
+    fromNative(torchNative.transpose(input.native, dim0.toLong, dim1.toLong))
 
   /** Removes a tensor dimension.
     *
@@ -1412,7 +1414,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
   def unbind[D <: DType](input: Tensor[D], dim: Int = 0): Seq[Tensor[D]] = {
     val result = torchNative.unbind(input.native, dim.toLong)
-    (0L until result.size()).map(i => Tensor(result.get(i)))
+    (0L until result.size()).map(i => fromNative(result.get(i)))
   }
 
   /** Returns a new tensor with a dimension of size one inserted at the specified position.
@@ -1443,7 +1445,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   the index at which to insert the singleton dimension
     */
   def unsqueeze[D <: DType](input: Tensor[D], dim: Int): Tensor[D] =
-    Tensor(torchNative.unsqueeze(input.native, dim.toLong))
+    fromNative(torchNative.unsqueeze(input.native, dim.toLong))
 
   /** Splits `input`, a tensor with two or more dimensions, into multiple tensors vertically
     * according to `indicesOrSections`. Each split is a view of `input`.
@@ -1471,7 +1473,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     */
   def vsplit[D <: DType](input: Tensor[D], splitSizeOrSections: Int*): Seq[Tensor[D]] = {
     val result = torchNative.vsplit(input.native, splitSizeOrSections.map(_.toLong)*)
-    (0L until result.size()).map(i => Tensor(result.get(i)))
+    (0L until result.size()).map(i => fromNative(result.get(i)))
   }
 
   /** Stack tensors in sequence vertically (row wise).
@@ -1492,7 +1494,7 @@ private[torch] trait IndexingSlicingJoiningOps {
     *
     * @group indexing_slicing_joining_mutating_ops
     */
-  def vstack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] = Tensor(
+  def vstack[D <: DType](tensors: Seq[Tensor[D]]): Tensor[D] = fromNative(
     torchNative.vstack(toArrayRef(tensors))
   )
 
@@ -1541,11 +1543,11 @@ private[torch] trait IndexingSlicingJoiningOps {
     *   When True (nonzero), yield input, otherwise yield other
     */
   def where[D <: DType](condition: Tensor[Bool], input: Tensor[D], other: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.where(condition.native, input.native, other.native))
+    fromNative(torchNative.where(condition.native, input.native, other.native))
   def where[D <: DType](condition: Tensor[Bool], input: Tensor[D], other: ScalaType): Tensor[D] =
-    Tensor(torchNative.where(condition.native, input.native, other.toScalar))
+    fromNative(torchNative.where(condition.native, input.native, other.toScalar))
   def where[D <: DType](condition: Tensor[Bool], input: ScalaType, other: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.where(condition.native, input.toScalar, other.native))
+    fromNative(torchNative.where(condition.native, input.toScalar, other.native))
   def where[D <: DType](condition: Tensor[Bool], input: ScalaType, other: ScalaType): Tensor[D] =
-    Tensor(torchNative.where(condition.native, input.toScalar, other.toScalar))
+    fromNative(torchNative.where(condition.native, input.toScalar, other.toScalar))
 }

--- a/core/src/main/scala/torch/ops/OtherOps.scala
+++ b/core/src/main/scala/torch/ops/OtherOps.scala
@@ -122,8 +122,8 @@ private[torch] trait OtherOps {
     */
   def einsum[D <: DType](equation: String, operands: Tensor[D]*): Tensor[D] =
     // TODO the equation input is not yet working, see https://github.com/bytedeco/javacpp-presets/discussions/1390
-    Tensor(torchNative.einsum(BytePointer(equation), toArrayRef(operands)))
+    fromNative(torchNative.einsum(BytePointer(equation), toArrayRef(operands)))
 
   /** Returns the sum of the elements of the diagonal of the input 2-D matrix. */
-  def trace[D <: DType](input: Tensor[D]): Tensor[D] = Tensor(torchNative.trace(input.native))
+  def trace[D <: DType](input: Tensor[D]): Tensor[D] = fromNative(torchNative.trace(input.native))
 }

--- a/core/src/main/scala/torch/ops/PointwiseOps.scala
+++ b/core/src/main/scala/torch/ops/PointwiseOps.scala
@@ -32,28 +32,28 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def abs[D <: NumericNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.abs(input.native))
+    fromNative(torchNative.abs(input.native))
 
   /** Computes the inverse cosine of each element in `input`.
     *
     * @group pointwise_ops
     */
   def acos[D <: DType](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.acos(input.native))
+    fromNative(torchNative.acos(input.native))
 
   /** Returns a new tensor with the inverse hyperbolic cosine of the elements of `input` .
     *
     * @group pointwise_ops
     */
   def acosh[D <: DType](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.acosh(input.native))
+    fromNative(torchNative.acosh(input.native))
 
   /** Adds `other` to `input`.
     *
     * @group pointwise_ops
     */
   def add[D <: DType, D2 <: DType](input: Tensor[D], other: Tensor[D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.add(input.native, other.native))
+    fromNative(torchNative.add(input.native, other.native))
 
   /** Adds `other` to `input`.
     *
@@ -63,7 +63,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: S
   ): Tensor[Promoted[D, ScalaToDType[S]]] =
-    Tensor(torchNative.add(input.native, toScalar(other)))
+    fromNative(torchNative.add(input.native, toScalar(other)))
 
   /** Performs the element-wise division of tensor1 by tensor2, multiplies the result by the scalar
     * value and adds it to input.
@@ -76,7 +76,7 @@ private[torch] trait PointwiseOps {
       tensor2: Tensor[D3],
       value: ScalaType
   ): Tensor[Promoted[D, Promoted[D2, D3]]] =
-    Tensor(torchNative.addcdiv(input.native, tensor1.native, tensor2.native, toScalar(value)))
+    fromNative(torchNative.addcdiv(input.native, tensor1.native, tensor2.native, toScalar(value)))
 
   /** Performs the element-wise multiplication of tensor1 by tensor2, multiplies the result by the
     * scalar value and adds it to input.
@@ -89,42 +89,42 @@ private[torch] trait PointwiseOps {
       tensor2: Tensor[D3],
       value: ScalaType
   ): Tensor[Promoted[D, Promoted[D2, D3]]] =
-    Tensor(torchNative.addcmul(input.native, tensor1.native, tensor2.native, toScalar(value)))
+    fromNative(torchNative.addcmul(input.native, tensor1.native, tensor2.native, toScalar(value)))
 
   /** Computes the element-wise angle (in radians) of the given `input` tensor.
     *
     * @group pointwise_ops
     */
   def angle[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[ComplexToReal[D]]] =
-    Tensor(torchNative.angle(input.native))
+    fromNative(torchNative.angle(input.native))
 
   /** Returns a new tensor with the arcsine of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def asin[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.asin(input.native))
+    fromNative(torchNative.asin(input.native))
 
   /** Returns a new tensor with the inverse hyperbolic sine of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def asinh[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.asinh(input.native))
+    fromNative(torchNative.asinh(input.native))
 
   /** Returns a new tensor with the arctangent of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def atan[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.atan(input.native))
+    fromNative(torchNative.atan(input.native))
 
   /** Returns a new tensor with the inverse hyperbolic tangent of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def atanh[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.atanh(input.native))
+    fromNative(torchNative.atanh(input.native))
 
   /** Element-wise arctangent of (input / other) with consideration of the quadrant. Returns a new
     * tensor with the signed angles in radians between vector (other, input) and vector (1, 0).
@@ -137,7 +137,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.atan2(input.native, other.native))
+    fromNative(torchNative.atan2(input.native, other.native))
 
   /** Computes the bitwise NOT of the given `input` tensor. The `input` tensor must be of integral
     * or Boolean types. For bool tensors, it computes the logical NOT.
@@ -145,7 +145,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def bitwiseNot[D <: BitwiseNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.bitwise_not(input.native))
+    fromNative(torchNative.bitwise_not(input.native))
 
   /** Computes the bitwise AND of `input` and `other`. For bool tensors, it computes the logical
     * AND.
@@ -156,7 +156,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.bitwise_and(input.native, other.native))
+    fromNative(torchNative.bitwise_and(input.native, other.native))
 
   /** Computes the bitwise OR of `input` and `other`. For bool tensors, it computes the logical OR.
     *
@@ -166,7 +166,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.bitwise_or(input.native, other.native))
+    fromNative(torchNative.bitwise_or(input.native, other.native))
 
   /** Computes the bitwise XOR of `input` and `other`. For bool tensors, it computes the logical
     * XOR.
@@ -177,7 +177,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.bitwise_xor(input.native, other.native))
+    fromNative(torchNative.bitwise_xor(input.native, other.native))
 
   /** Computes the left arithmetic shift of `input` by `other` bits.
     *
@@ -188,7 +188,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using OnlyOneBool[D, D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.bitwise_left_shift(input.native, other.native))
+    fromNative(torchNative.bitwise_left_shift(input.native, other.native))
 
   /** Computes the right arithmetic s\hift of `input` by `other` bits.
     *
@@ -198,7 +198,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using OnlyOneBool[D, D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.bitwise_right_shift(input.native, other.native))
+    fromNative(torchNative.bitwise_right_shift(input.native, other.native))
 
   /** Returns a new tensor with the ceil of the elements of `input`, the smallest integer greater
     * than or equal to each element.
@@ -206,7 +206,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def ceil[D <: NumericRealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.ceil(input.native))
+    fromNative(torchNative.ceil(input.native))
 
   /** Clamps all elements in `input` into the range [ min, max ]. Letting min_value and max_value be
     * min and max, respectively, this returns: `min(max(input, min_value), max_value)` If min is
@@ -220,7 +220,7 @@ private[torch] trait PointwiseOps {
       min: Option[Real],
       max: Option[Real]
   ): Tensor[D] =
-    Tensor(torchNative.clamp(input.native, toOptional(min), toOptional(max)))
+    fromNative(torchNative.clamp(input.native, toOptional(min), toOptional(max)))
 
   /** Computes the element-wise conjugate of the given `input` tensor. If input has a non-complex
     * dtype, this function just returns input.
@@ -228,7 +228,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def conjPhysical[D <: DType](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.conj_physical(input.native))
+    fromNative(torchNative.conj_physical(input.native))
 
   /** Create a new floating-point tensor with the magnitude of input and the sign of other,
     * elementwise.
@@ -239,7 +239,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: TensorOrReal[D2]
   ): Tensor[FloatPromoted[D]] =
-    Tensor(
+    fromNative(
       other match
         case other: Tensor[D2] =>
           torchNative.copysign(input.native, other.native)
@@ -252,14 +252,14 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def cos[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.cos(input.native))
+    fromNative(torchNative.cos(input.native))
 
   /** Returns a new tensor with the hyperbolic cosine of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def cosh[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.cosh(input.native))
+    fromNative(torchNative.cosh(input.native))
 
   /** Returns a new tensor with each of the elements of `input` converted from angles in degrees to
     * radians.
@@ -267,7 +267,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def deg2rad[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.deg2rad(input.native))
+    fromNative(torchNative.deg2rad(input.native))
 
   /** Divides each element of the input `input` by the corresponding element of `other`.
     *
@@ -278,13 +278,13 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.div(input.native, other.native))
+    fromNative(torchNative.div(input.native, other.native))
 
   def div[D <: DType, S <: ScalaType](
       input: Tensor[D],
       other: S
   ): Tensor[FloatPromoted[Promoted[D, ScalaToDType[S]]]] =
-    Tensor(torchNative.div(input.native, toScalar(other)))
+    fromNative(torchNative.div(input.native, toScalar(other)))
 
   export torch.special.digamma
   export torch.special.erf
@@ -296,7 +296,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def exp[D <: DType](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.exp(input.native))
+    fromNative(torchNative.exp(input.native))
 
   export torch.special.exp2
   export torch.special.expm1
@@ -314,7 +314,7 @@ private[torch] trait PointwiseOps {
       quantMin: Long,
       quantMax: Long
   ): Tensor[Float32] =
-    Tensor(
+    fromNative(
       torchNative.fake_quantize_per_channel_affine(
         input.native,
         scale.native,
@@ -337,7 +337,7 @@ private[torch] trait PointwiseOps {
       quantMin: Long,
       quantMax: Long
   ): Tensor[Float32] =
-    Tensor(
+    fromNative(
       torchNative.fake_quantize_per_tensor_affine(
         input.native,
         scale.native,
@@ -354,7 +354,7 @@ private[torch] trait PointwiseOps {
       quantMin: Long,
       quantMax: Long
   ): Tensor[Float32] =
-    Tensor(
+    fromNative(
       torchNative.fake_quantize_per_tensor_affine(
         input.native,
         scale,
@@ -370,7 +370,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def fix[D <: NumericRealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.fix(input.native))
+    fromNative(torchNative.fix(input.native))
 
   /** Raises `input` to the power of `exponent`, elementwise, in double precision. If neither input
     * is complex returns a `torch.float64` tensor, and if one or more inputs is complex returns a
@@ -382,19 +382,19 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       exponent: Tensor[D2]
   ): Tensor[ComplexPromoted[D, D2]] =
-    Tensor(torchNative.float_power(input.native, exponent.native))
+    fromNative(torchNative.float_power(input.native, exponent.native))
 
   def floatPower[D <: DType, S <: ScalaType](
       input: S,
       exponent: Tensor[D]
   ): Tensor[ComplexPromoted[ScalaToDType[S], D]] =
-    Tensor(torchNative.float_power(toScalar(input), exponent.native))
+    fromNative(torchNative.float_power(toScalar(input), exponent.native))
 
   def floatPower[D <: DType, S <: ScalaType](
       input: Tensor[D],
       exponent: ScalaType
   ): Tensor[ComplexPromoted[D, ScalaToDType[S]]] =
-    Tensor(torchNative.float_power(input.native, toScalar(exponent)))
+    fromNative(torchNative.float_power(input.native, toScalar(exponent)))
 
   /** Returns a new tensor with the floor of the elements of `input`, the largest integer less than
     * or equal to each element.
@@ -402,7 +402,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def floor[D <: NumericRealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.floor(input.native))
+    fromNative(torchNative.floor(input.native))
 
   /** Computes `input` divided by `other`, elementwise, and floors the result.
     *
@@ -412,13 +412,13 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using OnlyOneBool[D, D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.floor_divide(input.native, other.native))
+    fromNative(torchNative.floor_divide(input.native, other.native))
 
   def floorDivide[D <: RealNN, R <: Real](
       input: Tensor[D],
       other: R
   )(using OnlyOneBool[D, ScalaToDType[R]]): Tensor[Promoted[D, ScalaToDType[R]]] =
-    Tensor(torchNative.floor_divide(input.native, toScalar(other)))
+    fromNative(torchNative.floor_divide(input.native, toScalar(other)))
 
   /** Applies C++’s `std::fmod` entrywise. The result has the same sign as the dividend `input` and
     * its absolute value is less than that of `other`.
@@ -430,20 +430,20 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using OnlyOneBool[D, D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.fmod(input.native, other.native))
+    fromNative(torchNative.fmod(input.native, other.native))
 
   def fmod[D <: RealNN, S <: ScalaType](
       input: Tensor[D],
       other: S
   )(using OnlyOneBool[D, ScalaToDType[S]]): Tensor[Promoted[D, ScalaToDType[S]]] =
-    Tensor(torchNative.fmod(input.native, toScalar(other)))
+    fromNative(torchNative.fmod(input.native, toScalar(other)))
 
   /** Computes the fractional portion of each element in `input`.
     *
     * @group pointwise_ops
     */
   def frac[D <: FloatNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.frac(input.native))
+    fromNative(torchNative.frac(input.native))
 
   /** Decomposes `input` into `mantissa` and `exponent` tensors such that `input = mantissa * (2 **
     * exponent)` The range of mantissa is the open interval (-1, 1).
@@ -452,7 +452,7 @@ private[torch] trait PointwiseOps {
     */
   def frexp[D <: FloatNN](input: Tensor[D]): (Tensor[FloatPromoted[D]], Tensor[Int32]) =
     val nativeTuple = torchNative.frexp(input.native)
-    (Tensor(nativeTuple.get0), new Int32Tensor(nativeTuple.get1))
+    (fromNative(nativeTuple.get0), new Int32Tensor(nativeTuple.get1))
 
   /** Estimates the gradient of a function g:Rn → R in one or more dimensions using the second-order
     * accurate central differences method.
@@ -468,7 +468,7 @@ private[torch] trait PointwiseOps {
     torchNative
       .gradient(input.native, toScalar(spacing), dim.toArray.map(_.toLong), edgeOrder)
       .get
-      .map(Tensor.apply[D])
+      .map(fromNative[D])
 
   /** Returns a new tensor containing imaginary values of the `input` tensor. The returned tensor
     * and `input` share the same underlying storage.
@@ -476,14 +476,14 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def imag[D <: ComplexNN](input: Tensor[D]): Tensor[ComplexToReal[D]] =
-    Tensor(torchNative.imag(input.native))
+    fromNative(torchNative.imag(input.native))
 
   /** Multiplies `input` by 2 ** `other`.
     *
     * @group pointwise_ops
     */
   def ldexp[D <: DType](input: Tensor[D], other: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.ldexp(input.native, other.native))
+    fromNative(torchNative.ldexp(input.native, other.native))
 
   /** Does a linear interpolation of two tensors `start` (given by `input`) and `end` (given by
     * `other`) based on a scalar or tensor weight and returns the resulting out tensor. out = start
@@ -496,7 +496,7 @@ private[torch] trait PointwiseOps {
       other: Tensor[D],
       weight: Tensor[D] | Float | Double
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       weight match
         case weight: Tensor[D] => torchNative.lerp(input.native, other.native, weight.native)
         case weight: Float     => torchNative.lerp(input.native, other.native, toScalar(weight))
@@ -508,35 +508,35 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def lgamma[D <: RealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.lgamma(input.native))
+    fromNative(torchNative.lgamma(input.native))
 
   /** Returns a new tensor with the natural logarithm of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def log[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.log(input.native))
+    fromNative(torchNative.log(input.native))
 
   /** Returns a new tensor with the logarithm to the base 10 of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def log10[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.log10(input.native))
+    fromNative(torchNative.log10(input.native))
 
   /** Returns a new tensor with the natural logarithm of (1 + input).
     *
     * @group pointwise_ops
     */
   def log1p[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.log1p(input.native))
+    fromNative(torchNative.log1p(input.native))
 
   /** Returns a new tensor with the logarithm to the base 2 of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def log2[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.log2(input.native))
+    fromNative(torchNative.log2(input.native))
 
   /** Logarithm of the sum of exponentiations of the inputs. Calculates pointwise log `log(e**x +
     * e**y)`. This function is useful in statistics where the calculated probabilities of events may
@@ -551,7 +551,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.logaddexp(input.native, other.native))
+    fromNative(torchNative.logaddexp(input.native, other.native))
 
   /** Logarithm of the sum of exponentiations of the inputs in base-2. Calculates pointwise
     * `log2(2**x + 2**y)`. See torch.logaddexp() for more details.
@@ -562,7 +562,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.logaddexp2(input.native, other.native))
+    fromNative(torchNative.logaddexp2(input.native, other.native))
 
   /** Computes the element-wise logical AND of the given `input` tensors. Zeros are treated as False
     * and nonzeros are treated as True.
@@ -570,7 +570,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def logicalAnd[D <: DType, D2 <: DType](input: Tensor[D], other: Tensor[D2]): Tensor[Bool] =
-    Tensor(torchNative.logical_and(input.native, other.native))
+    fromNative(torchNative.logical_and(input.native, other.native))
 
   /** Computes the element-wise logical NOT of the given `input` tensor. If the `input` tensor is
     * not a bool tensor, zeros are treated as False and non-zeros are treated as True.
@@ -580,7 +580,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def logicalNot[D <: DType](input: Tensor[D]): Tensor[Bool] =
-    Tensor(torchNative.logical_not(input.native))
+    fromNative(torchNative.logical_not(input.native))
 
   /** Computes the element-wise logical OR of the given `input` tensors. Zeros are treated as False
     * and nonzeros are treated as True.
@@ -588,7 +588,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def logicalOr[D <: DType, D2 <: DType](input: Tensor[D], other: Tensor[D2]): Tensor[Bool] =
-    Tensor(torchNative.logical_or(input.native, other.native))
+    fromNative(torchNative.logical_or(input.native, other.native))
 
   /** Computes the element-wise logical XOR of the given `input` tensors. Zeros are treated as False
     * and nonzeros are treated as True.
@@ -596,7 +596,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def logicalXor[D <: DType, D2 <: DType](input: Tensor[D], other: Tensor[D2]): Tensor[Bool] =
-    Tensor(torchNative.logical_xor(input.native, other.native))
+    fromNative(torchNative.logical_xor(input.native, other.native))
 
   export torch.special.logit
 
@@ -609,7 +609,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using AtLeastOneFloat[D, D2]): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.hypot(input.native, other.native))
+    fromNative(torchNative.hypot(input.native, other.native))
 
   export torch.special.i0
   export torch.special.igamma
@@ -620,7 +620,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def mul[D <: DType, D2 <: DType](input: Tensor[D], other: Tensor[D2]): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.mul(input.native, other.native))
+    fromNative(torchNative.mul(input.native, other.native))
 
   export torch.special.mvlgamma
 
@@ -637,7 +637,7 @@ private[torch] trait PointwiseOps {
       posinf: Option[Double] = None,
       neginf: Option[Double] = None
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.nan_to_num(input.native, toOptional(nan), toOptional(posinf), toOptional(neginf))
     )
 
@@ -646,7 +646,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def neg[D <: NumericNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.neg(input.native))
+    fromNative(torchNative.neg(input.native))
 
   /** Return the next floating-point value after `input` towards `other`, elementwise.
     *
@@ -657,7 +657,7 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   )(using AtLeastOneFloat[D, D2]): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.nextafter(input.native, other.native))
+    fromNative(torchNative.nextafter(input.native, other.native))
 
   export torch.special.polygamma
 
@@ -666,7 +666,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def positive[D <: NumericNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.positive(input.native))
+    fromNative(torchNative.positive(input.native))
 
   /** Takes the power of each element in `input` with exponent and returns a tensor with the result.
     * `exponent` can be either a single float number or a Tensor with the same number of elements as
@@ -680,7 +680,7 @@ private[torch] trait PointwiseOps {
       @implicitNotFound(""""pow" not implemented for complex32""")
       ev2: Promoted[D, D2] NotEqual Complex32
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.pow(input.native, exponent.native))
+    fromNative(torchNative.pow(input.native, exponent.native))
 
   def pow[D <: DType, S <: ScalaType](input: Tensor[D], exponent: S)(using
       @implicitNotFound(""""pow" not implemented for bool""")
@@ -688,7 +688,7 @@ private[torch] trait PointwiseOps {
       @implicitNotFound(""""pow" not implemented for complex32""")
       ev2: Promoted[D, ScalaToDType[S]] NotEqual Complex32
   ): Tensor[Promoted[D, ScalaToDType[S]]] =
-    Tensor(torchNative.pow(input.native, toScalar(exponent)))
+    fromNative(torchNative.pow(input.native, toScalar(exponent)))
 
   def pow[S <: ScalaType, D <: DType](input: S, exponent: Tensor[D])(using
       @implicitNotFound(""""pow" not implemented for bool""")
@@ -696,7 +696,7 @@ private[torch] trait PointwiseOps {
       @implicitNotFound(""""pow" not implemented for complex32""")
       ev2: Promoted[D, ScalaToDType[S]] NotEqual Complex32
   ): Tensor[Promoted[ScalaToDType[S], D]] =
-    Tensor(torchNative.pow(toScalar(input), exponent.native))
+    fromNative(torchNative.pow(toScalar(input), exponent.native))
 
 // TODO Implement creation of QInts
 // TODO quantized_batch_norm
@@ -709,7 +709,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def rad2Deg[D <: RealNN | Bool](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.rad2deg(input.native))
+    fromNative(torchNative.rad2deg(input.native))
 
   /** Returns a new tensor containing real values of the self tensor. The returned tensor and self
     * share the same underlying storage.
@@ -717,14 +717,14 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def real[D <: DType](input: Tensor[D]): Tensor[ComplexToReal[D]] =
-    Tensor(torchNative.real(input.native))
+    fromNative(torchNative.real(input.native))
 
   /** Returns a new tensor with the reciprocal of the elements of `input`
     *
     * @group pointwise_ops
     */
   def reciprocal[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.reciprocal(input.native))
+    fromNative(torchNative.reciprocal(input.native))
 
   /** Computes Python’s modulus operation entrywise. The result has the same sign as the divisor
     * `other` and its absolute value is less than that of `other`.
@@ -735,19 +735,19 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.remainder(input.native, other.native))
+    fromNative(torchNative.remainder(input.native, other.native))
 
   def remainder[D <: DType, R <: Real](
       input: Tensor[D],
       other: R
   ): Tensor[Promoted[D, ScalaToDType[R]]] =
-    Tensor(torchNative.remainder(input.native, toScalar(other)))
+    fromNative(torchNative.remainder(input.native, toScalar(other)))
 
   def remainder[D <: DType, R <: Real](
       input: R,
       other: Tensor[D]
   ): Tensor[Promoted[ScalaToDType[R], D]] =
-    Tensor(torchNative.remainder(toScalar(input), other.native))
+    fromNative(torchNative.remainder(toScalar(input), other.native))
 
   /** Rounds elements of `input` to the nearest integer. If decimals is negative, it specifies the
     * number of positions to the left of the decimal point.
@@ -755,7 +755,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def round[D <: FloatNN](input: Tensor[D], decimals: Long = 0): Tensor[D] =
-    Tensor(torchNative.round(input.native, decimals))
+    fromNative(torchNative.round(input.native, decimals))
 
   /** Returns a new tensor with the reciprocal of the square-root of each of the elements of
     * `input`.
@@ -763,7 +763,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def rsqrt[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.rsqrt(input.native))
+    fromNative(torchNative.rsqrt(input.native))
 
   export torch.special.sigmoid
 
@@ -772,7 +772,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def sign[D <: RealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.sign(input.native))
+    fromNative(torchNative.sign(input.native))
 
   /** This function is an extension of `torch.sign()` to complex tensors. It computes a new tensor
     * whose elements have the same angles as the corresponding elements of `input` and absolute
@@ -782,21 +782,21 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def sgn[D <: DType](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.sgn(input.native))
+    fromNative(torchNative.sgn(input.native))
 
   /** Tests if each element of `input`` has its sign bit set or not.
     *
     * @group pointwise_ops
     */
   def signbit[D <: RealNN](input: Tensor[D]): Tensor[Bool] =
-    Tensor(torchNative.signbit(input.native))
+    fromNative(torchNative.signbit(input.native))
 
   /** Returns a new tensor with the sine of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def sin[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.sin(input.native))
+    fromNative(torchNative.sin(input.native))
 
   export torch.special.sinc
 
@@ -805,7 +805,7 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def sinh[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.sinh(input.native))
+    fromNative(torchNative.sinh(input.native))
 
   export torch.nn.functional.softmax
 
@@ -814,14 +814,14 @@ private[torch] trait PointwiseOps {
     * @group pointwise_ops
     */
   def sqrt[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.sqrt(input.native))
+    fromNative(torchNative.sqrt(input.native))
 
   /** Returns a new tensor with the square of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def square[D <: DType](input: Tensor[D]): Tensor[NumericPromoted[D]] =
-    Tensor(torchNative.square(input.native))
+    fromNative(torchNative.square(input.native))
 
   /** Subtracts `other`, scaled by `alpha`, from `input`.
     *
@@ -831,35 +831,35 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.sub(input.native, other.native))
+    fromNative(torchNative.sub(input.native, other.native))
 
   def sub[D <: NumericNN, D2 <: NumericNN](
       input: Tensor[D],
       other: Tensor[D2],
       alpha: ScalaType
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.sub(input.native, other.native, toScalar(alpha)))
+    fromNative(torchNative.sub(input.native, other.native, toScalar(alpha)))
 
   def sub[D <: NumericNN, D2 <: NumericNN](
       input: Tensor[D],
       other: Numeric,
       alpha: ScalaType
   ): Tensor[Promoted[D, D2]] =
-    Tensor(torchNative.sub(input.native, toScalar(other), toScalar(alpha)))
+    fromNative(torchNative.sub(input.native, toScalar(other), toScalar(alpha)))
 
   /** Returns a new tensor with the tangent of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def tan[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.tan(input.native))
+    fromNative(torchNative.tan(input.native))
 
   /** Returns a new tensor with the hyperbolic tangent of the elements of `input`.
     *
     * @group pointwise_ops
     */
   def tanh[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.tanh(input.native))
+    fromNative(torchNative.tanh(input.native))
 
   /** Alias for `torch.div()` with `rounding_mode=None`
     *
@@ -869,20 +869,20 @@ private[torch] trait PointwiseOps {
       input: Tensor[D],
       other: Tensor[D2]
   ): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.true_divide(input.native, other.native))
+    fromNative(torchNative.true_divide(input.native, other.native))
 
   def trueDivide[D <: DType, S <: ScalaType](
       input: Tensor[D],
       other: S
   ): Tensor[FloatPromoted[Promoted[D, ScalaToDType[S]]]] =
-    Tensor(torchNative.true_divide(input.native, toScalar(other)))
+    fromNative(torchNative.true_divide(input.native, toScalar(other)))
 
   /** Returns a new tensor with the truncated integer values of the elements of `input`
     *
     * @group pointwise_ops
     */
   def trunc[D <: NumericRealNN](input: Tensor[D]): Tensor[D] =
-    Tensor(torchNative.trunc(input.native))
+    fromNative(torchNative.trunc(input.native))
 
   export torch.special.xlogy
 }

--- a/core/src/main/scala/torch/ops/RandomSamplingOps.scala
+++ b/core/src/main/scala/torch/ops/RandomSamplingOps.scala
@@ -45,7 +45,7 @@ private[torch] trait RandomSamplingOps {
       replacement: Boolean = false,
       generator: Option[Generator] | Generator = None
   ): Tensor[Int64] =
-    Tensor(torchNative.multinomial(input.native, numSamples, replacement, generator.toOptional))
+    fromNative(torchNative.multinomial(input.native, numSamples, replacement, generator.toOptional))
 
 // TODO normal Returns a tensor of random numbers drawn from separate normal distributions whose mean and standard deviation are given.
 // TODO poisson Returns a tensor of the same size as input with each element sampled from a Poisson distribution with rate parameter given by the corresponding element in input i.e.,
@@ -75,7 +75,7 @@ private[torch] trait RandomSamplingOps {
       device: Device = CPU,
       requiresGrad: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_rand(
         size.toArray.map(_.toLong),
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)
@@ -145,7 +145,7 @@ private[torch] trait RandomSamplingOps {
       device: Device = CPU,
       requiresGrad: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_randint(
         low,
         high,
@@ -165,7 +165,7 @@ private[torch] trait RandomSamplingOps {
       device: Device = CPU,
       requiresGrad: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_randn(
         size.toArray.map(_.toLong),
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad)
@@ -186,7 +186,7 @@ private[torch] trait RandomSamplingOps {
       requiresGrad: Boolean = false,
       pinMemory: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.torch_randperm(
         n,
         NativeConverters.tensorOptions(dtype, layout, device, requiresGrad, pinMemory)

--- a/core/src/main/scala/torch/ops/ReductionOps.scala
+++ b/core/src/main/scala/torch/ops/ReductionOps.scala
@@ -68,7 +68,7 @@ private[torch] trait ReductionOps {
       input: Tensor[D],
       dim: Int | Option[Int] = None,
       keepdim: Boolean = false
-  ): Tensor[Int64] = Tensor(
+  ): Tensor[Int64] = fromNative(
     torchNative.argmax(input.native, dim.toOptional, keepdim)
   )
 
@@ -97,7 +97,7 @@ private[torch] trait ReductionOps {
       input: Tensor[D],
       dim: Int | Option[Int] = None,
       keepdim: Boolean = false
-  ): Tensor[Int64] = Tensor(
+  ): Tensor[Int64] = fromNative(
     torchNative.argmin(input.native, dim.toOptional, keepdim)
   )
 
@@ -118,7 +118,7 @@ private[torch] trait ReductionOps {
       dim: Int | Seq[Int],
       keepdim: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.amax(input.native, dim.toArray, keepdim)
     )
 
@@ -139,7 +139,7 @@ private[torch] trait ReductionOps {
       dim: Int | Seq[Int],
       keepdim: Boolean = false
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.amin(input.native, dim.toArray, keepdim)
     )
 
@@ -160,13 +160,13 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false
   ): (Tensor[D], Tensor[D]) =
     val native = torchNative.aminmax(input.native, dim.toOptional, keepdim)
-    (Tensor(native.get0()), Tensor(native.get1()))
+    (fromNative(native.get0()), fromNative(native.get1()))
 
   /** Tests if all elements of this tensor evaluate to `true`.
     *
     * @group reduction_ops
     */
-  def all[D <: DType](input: Tensor[D]): Tensor[Bool] = Tensor(torchNative.all(input.native))
+  def all[D <: DType](input: Tensor[D]): Tensor[Bool] = fromNative(torchNative.all(input.native))
 
   /** For each row of `input` in the given dimension `dim`, returns `true` if all elements in the
     * row evaluate to `true` and `false` otherwise.
@@ -180,15 +180,16 @@ private[torch] trait ReductionOps {
     * @param keepdim
     *   whether the output tensor has `dim` retained or not.
     */
-  def all[D <: DType](input: Tensor[D], dim: Int, keepdim: Boolean = false): Tensor[Bool] = Tensor(
-    torchNative.all(input.native, dim, keepdim)
-  )
+  def all[D <: DType](input: Tensor[D], dim: Int, keepdim: Boolean = false): Tensor[Bool] =
+    fromNative(
+      torchNative.all(input.native, dim, keepdim)
+    )
 
   /** Tests if any elements of this tensor evaluate to `true`.
     *
     * @group reduction_ops
     */
-  def any[D <: DType](input: Tensor[D]): Tensor[Bool] = Tensor(torchNative.any(input.native))
+  def any[D <: DType](input: Tensor[D]): Tensor[Bool] = fromNative(torchNative.any(input.native))
 
   /** For each row of `input` in the given dimension `dim`, returns `true` if any element in the row
     * evaluates to `true` and `false` otherwise.
@@ -202,15 +203,16 @@ private[torch] trait ReductionOps {
     * @param keepdim
     *   whether the output tensor has `dim` retained or not.
     */
-  def any[D <: DType](input: Tensor[D], dim: Int, keepdim: Boolean = false): Tensor[Bool] = Tensor(
-    torchNative.any(input.native, dim, keepdim)
-  )
+  def any[D <: DType](input: Tensor[D], dim: Int, keepdim: Boolean = false): Tensor[Bool] =
+    fromNative(
+      torchNative.any(input.native, dim, keepdim)
+    )
 
   /** Returns the maximum value of all elements in the `input` tensor.
     *
     * @group reduction_ops
     */
-  def max[D <: RealNN](input: Tensor[D]): Tensor[Int64] = Tensor(input.native.max())
+  def max[D <: RealNN](input: Tensor[D]): Tensor[Int64] = fromNative(input.native.max())
 
   /** Returns a [[TensorTuple]] `(values, indices)` where `values` is the maximum value of each row
     * of the `input` tensor in the given dimension `dim`. And `indices` is the index location of
@@ -231,13 +233,16 @@ private[torch] trait ReductionOps {
     */
   def max[D <: RealNN](input: Tensor[D], dim: Int, keepdim: Boolean = false): TensorTuple[D] =
     val nativeTuple = torchNative.max(input.native, dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(
+      values = fromNative[D](nativeTuple.get0),
+      indices = new Int64Tensor(nativeTuple.get1)
+    )
 
   /** Returns the maximum value of all elements in the `input` tensor.
     *
     * @group reduction_ops
     */
-  def min[D <: RealNN](input: Tensor[D]): Tensor[Int64] = Tensor(input.native.min())
+  def min[D <: RealNN](input: Tensor[D]): Tensor[Int64] = fromNative(input.native.min())
 
   /** Returns a [[TensorTuple]] `(values, indices)` where `values` is the minimum value of each row
     * of the `input` tensor in the given dimension `dim`. And `indices` is the index location of
@@ -258,7 +263,10 @@ private[torch] trait ReductionOps {
     */
   def min[D <: RealNN](input: Tensor[D], dim: Int, keepdim: Boolean = false): TensorTuple[D] =
     val nativeTuple = torchNative.min(input.native, dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(
+      values = fromNative[D](nativeTuple.get0),
+      indices = new Int64Tensor(nativeTuple.get1)
+    )
 
   /** Returns the p-norm of (`input` - `other`)
     *
@@ -276,7 +284,7 @@ private[torch] trait ReductionOps {
   )(using
       AtLeastOneFloat[D, D2]
   ): Tensor[Promoted[FloatPromoted[ComplexToReal[D]], FloatPromoted[ComplexToReal[D2]]]] =
-    Tensor(torchNative.dist(input.native, other.native, toScalar(p)))
+    fromNative(torchNative.dist(input.native, other.native, toScalar(p)))
 
   /** Returns the log of summed exponentials of each row of the `input` tensor in the given
     * dimension `dim`. The computation is numerically stabilized.
@@ -298,7 +306,7 @@ private[torch] trait ReductionOps {
       input: Tensor[D],
       dim: Int | Seq[Int] = Seq.empty,
       keepdim: Boolean = false
-  ): Tensor[D] = Tensor(
+  ): Tensor[D] = fromNative(
     torchNative.logsumexp(input.native, dim.toArray, keepdim)
   )
 
@@ -326,7 +334,7 @@ private[torch] trait ReductionOps {
     val derivedDType = dtype match
       case _: Derive => input.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.mean(
         input.native,
         dim.toArray,
@@ -363,7 +371,7 @@ private[torch] trait ReductionOps {
     val derivedDType = dtype match
       case _: Derive => input.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.nanmean(
         input.native,
         dim.toArray,
@@ -387,7 +395,7 @@ private[torch] trait ReductionOps {
       */
   def median[D <: NumericRealNN](
       input: Tensor[D]
-  ): Tensor[D] = Tensor(torchNative.median(input.native))
+  ): Tensor[D] = fromNative(torchNative.median(input.native))
 
   /** Returns a [[TensorTuple]] `(values, indices)` where `values` contains the median of each row
     * of `input` in the dimension `dim`, and `indices` contains the index of the median values found
@@ -424,7 +432,10 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false
   ): TensorTuple[D] =
     val nativeTuple = torchNative.median(input.native, dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(
+      values = fromNative[D](nativeTuple.get0),
+      indices = new Int64Tensor(nativeTuple.get1)
+    )
 
     /** Returns the median of the values in `input`, ignoring `NaN` values.
       *
@@ -437,7 +448,7 @@ private[torch] trait ReductionOps {
       */
   def nanmedian[D <: NumericRealNN](
       input: Tensor[D]
-  ): Tensor[D] = Tensor(torchNative.nanmedian(input.native))
+  ): Tensor[D] = fromNative(torchNative.nanmedian(input.native))
 
   /** Returns a [[TensorTuple]] ``(values, indices)`` where ``values`` contains the median of each
     * row of `input` in the dimension `dim`, ignoring ``NaN`` values, and ``indices`` contains the
@@ -464,7 +475,10 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false
   ): TensorTuple[D] =
     val nativeTuple = torchNative.nanmedian(input.native, dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(
+      values = fromNative[D](nativeTuple.get0),
+      indices = new Int64Tensor(nativeTuple.get1)
+    )
 
   /** Returns a [[TensorTuple]] `(values, indices)` where `values` is the mode value of each row of
     * the `input` tensor in the given dimension `dim`,
@@ -491,7 +505,10 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false
   ): TensorTuple[D] =
     val nativeTuple = torchNative.mode(input.native, dim, keepdim)
-    TensorTuple(values = Tensor[D](nativeTuple.get0), indices = new Int64Tensor(nativeTuple.get1))
+    TensorTuple(
+      values = fromNative[D](nativeTuple.get0),
+      indices = new Int64Tensor(nativeTuple.get1)
+    )
 
   /** Returns the sum of each row of the `input` tensor in the given dimension `dim`, treating Not a
     * Numbers (NaNs) as zero. If `dim` is a list of dimensions, reduce over all of them.
@@ -517,7 +534,7 @@ private[torch] trait ReductionOps {
     val derivedDType = dtype match
       case _: Derive => input.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.nansum(
         input.native,
         dim.toArray,
@@ -532,7 +549,7 @@ private[torch] trait ReductionOps {
     */
   def prod[D <: DType, D2 <: DType | Derive](
       input: Tensor[D]
-  ): Tensor[D] = Tensor(torchNative.prod(input.native))
+  ): Tensor[D] = fromNative(torchNative.prod(input.native))
 
   /** Returns the product of all elements in the `input` tensor.
     *
@@ -544,7 +561,9 @@ private[torch] trait ReductionOps {
   def prod[D <: DType](
       input: Tensor[?],
       dtype: D
-  ): Tensor[D] = Tensor(torchNative.prod(input.native, new ScalarTypeOptional(dtype.toScalarType)))
+  ): Tensor[D] = fromNative(
+    torchNative.prod(input.native, new ScalarTypeOptional(dtype.toScalarType))
+  )
 
   /** Returns the product of each row of the `input` tensor in the given dimension `dim`.
     *
@@ -569,7 +588,7 @@ private[torch] trait ReductionOps {
     val derivedDType = dtype match
       case _: Derive => input.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.prod(
         input.native,
         dim,
@@ -619,7 +638,7 @@ private[torch] trait ReductionOps {
 //     keepdim: Boolean = false,
 
 // ): Tensor[DTypeOrDeriveFromTensor[D, D2]] =
-//   Tensor(
+//   fromNative(
 //     torchNative.quantile(
 //       input.native,
 //       q,
@@ -660,7 +679,7 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false,
       correction: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.std(
         input.native,
         dim.toArray,
@@ -706,7 +725,7 @@ private[torch] trait ReductionOps {
         correction.toOptional,
         keepdim
       )
-    (Tensor[D](nativeTuple.get0), Tensor[D](nativeTuple.get1))
+    (fromNative[D](nativeTuple.get0), fromNative[D](nativeTuple.get1))
 
   /** Returns the sum of all elements in the `input` tensor.
     *
@@ -714,7 +733,7 @@ private[torch] trait ReductionOps {
     */
   def sum[D <: DType, D2 <: DType | Derive](
       input: Tensor[D]
-  ): Tensor[D] = Tensor(torchNative.sum(input.native))
+  ): Tensor[D] = fromNative(torchNative.sum(input.native))
 
   /** Returns the sum of all elements in the `input` tensor.
     *
@@ -726,7 +745,9 @@ private[torch] trait ReductionOps {
   def sum[D <: DType](
       input: Tensor[?],
       dtype: D
-  ): Tensor[D] = Tensor(torchNative.sum(input.native, new ScalarTypeOptional(dtype.toScalarType)))
+  ): Tensor[D] = fromNative(
+    torchNative.sum(input.native, new ScalarTypeOptional(dtype.toScalarType))
+  )
 
   /** Returns the sum of each row of the `input` tensor in the given dimension `dim`.
     *
@@ -753,7 +774,7 @@ private[torch] trait ReductionOps {
     val derivedDType = dtype match
       case _: Derive => input.dtype
       case d: DType  => d
-    Tensor(
+    fromNative(
       torchNative.sum(
         input.native,
         dim.toArray,
@@ -773,7 +794,7 @@ private[torch] trait ReductionOps {
     // TODO var
     /* TODO Calculates the variance over the dimensions specified by dim. */
     // def variance[D <: DType](input: Tensor[D], dim: Seq[Int] = Nil, correction: Option[Int] = None, keepdim: Boolean = false) =
-    //  Tensor(torchNative.`var`(input.native, dim.toArray.map(_.toLong), toOptional(correction), keepdim))
+    //  fromNative(torchNative.`var`(input.native, dim.toArray.map(_.toLong), toOptional(correction), keepdim))
 
   /** Calculates the variance over the dimensions specified by `dim`. `dim` can be a single
     * dimension, list of dimensions, or `None` to reduce over all dimensions.
@@ -803,7 +824,7 @@ private[torch] trait ReductionOps {
       keepdim: Boolean = false,
       correction: Int = 1
   ): Tensor[D] =
-    Tensor(
+    fromNative(
       torchNative.`var`(
         input.native,
         dim.toArray,
@@ -849,7 +870,7 @@ private[torch] trait ReductionOps {
         correction.toOptional,
         keepdim
       )
-    (Tensor[D](nativeTuple.get0), Tensor[D](nativeTuple.get1))
+    (fromNative[D](nativeTuple.get0), fromNative[D](nativeTuple.get1))
 
   /** Counts the number of non-zero values in the tensor `input` along the given `dim`. If no dim is
     * specified then all non-zeros in the tensor are counted.
@@ -864,7 +885,7 @@ private[torch] trait ReductionOps {
       dim: Int | Seq[Int] = Seq.empty
   ): Tensor[Int64] =
     val nativeDim = dim.toArray
-    Tensor(
+    fromNative(
       if nativeDim.isEmpty then torchNative.count_nonzero(input.native)
       else torchNative.count_nonzero(input.native, nativeDim: _*)
     )

--- a/core/src/main/scala/torch/ops/package.scala
+++ b/core/src/main/scala/torch/ops/package.scala
@@ -16,7 +16,7 @@
 
 package torch
 
-import internal.NativeConverters
+import internal.NativeConverters.{fromNative, tensorOptions}
 import org.bytedeco.pytorch.global.torch as torchNative
 import org.bytedeco.pytorch
 import org.bytedeco.pytorch.{MemoryFormatOptional, TensorArrayRef, TensorVector}
@@ -45,10 +45,10 @@ package object ops {
     val derivedDevice = device match
       case _: Derive => input.device
       case d: Device => d
-    Tensor(
+    fromNative(
       nativeFn(
         input.native,
-        NativeConverters.tensorOptions(derivedDType, derivedLayout, derivedDevice, requiresGrad),
+        tensorOptions(derivedDType, derivedLayout, derivedDevice, requiresGrad),
         new MemoryFormatOptional(memoryFormat.toNative)
       )
     )

--- a/core/src/main/scala/torch/special/package.scala
+++ b/core/src/main/scala/torch/special/package.scala
@@ -23,35 +23,35 @@ import internal.NativeConverters.*
 package object special:
   /** Computes the logarithmic derivative of the gamma function on `input`. */
   def digamma[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.digamma(input.native))
+    fromNative(torchNative.digamma(input.native))
 
   /** Computes the error function of `input`. */
   def erf[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.erf(input.native))
+    fromNative(torchNative.erf(input.native))
 
   /** Computes the complementary error function of `input`. */
   def erfc[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.erfc(input.native))
+    fromNative(torchNative.erfc(input.native))
 
   /** Computes the inverse error function of `input`. The inverse error function is defined in the
     * range (−1,1)
     */
   def erfinv[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.erfinv(input.native))
+    fromNative(torchNative.erfinv(input.native))
 
   /** Computes the base two exponential function of `input`. */
   def exp2[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.exp2(input.native))
+    fromNative(torchNative.exp2(input.native))
 
   /** Computes the exponential of the elements minus 1 of `input`. */
   def expm1[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.expm1(input.native))
+    fromNative(torchNative.expm1(input.native))
 
   /** Computes the zeroth order modified Bessel function of the first kind for each element of
     * `input`.
     */
   def i0[D <: RealNN](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.i0(input.native))
+    fromNative(torchNative.i0(input.native))
 
   /** Computes the regularized lower incomplete gamma function */
   // NOTE it is named `gammainc` in pytorch torch.special
@@ -60,7 +60,7 @@ package object special:
       input: Tensor[D],
       other: Tensor[D2]
   )(using AtLeastOneFloat[D, D2]): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.igamma(input.native, other.native))
+    fromNative(torchNative.igamma(input.native, other.native))
 
   /** Computes the regularized upper incomplete gamma function */
   // NOTE it is named `gamaincc` in pytorch torch.special
@@ -69,35 +69,35 @@ package object special:
       input: Tensor[D],
       other: Tensor[D2]
   )(using AtLeastOneFloat[D, D2]): Tensor[FloatPromoted[Promoted[D, D2]]] =
-    Tensor(torchNative.igammac(input.native, other.native))
+    fromNative(torchNative.igammac(input.native, other.native))
 
   /** Returns a new tensor with the logit of the elements of `input`. `input` is clamped to [eps, 1
     * \- eps] when eps is not None. When eps is None and input < 0 or input > 1, the function will
     * yields NaN.
     */
   def logit[D <: RealNN](input: Tensor[D], eps: Option[Double]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.logit(input.native, toOptional(eps)))
+    fromNative(torchNative.logit(input.native, toOptional(eps)))
 
   /** Computes the multivariate log-gamma function with dimension p element-wise */
   // NOTE it is named `multigammaln` in pytorch torch.special
   def mvlgamma[D <: NumericRealNN](input: Tensor[D], p: Int): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.mvlgamma(input.native, p))
+    fromNative(torchNative.mvlgamma(input.native, p))
 
   /** Computes the nth derivative of the digamma function on `input`. n≥0 is called the order of the
     * polygamma function.
     */
   def polygamma[D <: RealNN](n: Int, input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.polygamma(n, input.native))
+    fromNative(torchNative.polygamma(n, input.native))
 
   /** Computes the expit (also known as the logistic sigmoid function) of the elements of `input`.
     */
   // NOTE it is named `expit` in pytorch torch.special
   def sigmoid[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.sigmoid(input.native))
+    fromNative(torchNative.sigmoid(input.native))
 
   /** Returns a new tensor with the normalized sinc of the elements of `input`. */
   def sinc[D <: DType](input: Tensor[D]): Tensor[FloatPromoted[D]] =
-    Tensor(torchNative.sinc(input.native))
+    fromNative(torchNative.sinc(input.native))
 
   /** Computes `input * log(other)` with the following cases. */
   // TODO handle Scalar `input`
@@ -105,7 +105,7 @@ package object special:
       input: Tensor[D],
       other: TensorOrReal[D2]
   ): Tensor[FloatPromoted[D]] =
-    Tensor(
+    fromNative(
       other match
         case other: Tensor[D2] =>
           torchNative.xlogy(input.native, other.native)

--- a/core/src/test/scala/torch/TensorSuite.scala
+++ b/core/src/test/scala/torch/TensorSuite.scala
@@ -82,8 +82,8 @@ class TensorSuite extends TensorCheckSuite {
     tensor(Seq(0)) = 20
     assertEquals(tensor(0), torch.full(Seq(4), 20))
 
-    val updated = Tensor[Int](30)
-    tensor(Seq(1, 0)) = Tensor[Int](30)
+    val updated = Tensor(30)
+    tensor(Seq(1, 0)) = Tensor(30)
     assertEquals(tensor(1, 0), updated)
 
     // copy column 1 to column 0

--- a/core/src/test/scala/torch/nn/modules/EmbeddingSuite.scala
+++ b/core/src/test/scala/torch/nn/modules/EmbeddingSuite.scala
@@ -49,7 +49,7 @@ class EmbeddingSuite extends munit.FunSuite {
       torch.manualSeed(0)
       // example with padding_idx
       val embedding = nn.Embedding(5, 3, paddingIdx = Some(0))
-      embedding.weight = Tensor[Float](
+      embedding.weight = Tensor(
         Seq(
           Seq(0f, 0f, 0f),
           Seq(0.5684f, -1.0845f, -1.3986f),

--- a/core/src/test/scala/torch/ops/OtherOpsSuite.scala
+++ b/core/src/test/scala/torch/ops/OtherOpsSuite.scala
@@ -25,15 +25,15 @@ class OtherOpsSuite extends TensorCheckSuite {
     val b = torch.arange(end = 5)
     assert(torch.einsum("ii", a) equal torch.trace(a))
     // diagonal
-    assert(torch.einsum("ii->i", a) equal Tensor[Int](Seq(0, 6, 12, 18, 24)))
+    assert(torch.einsum("ii->i", a) equal Tensor(Seq(0, 6, 12, 18, 24)))
     // inner product
-    assert(torch.einsum("i,i", b, b) equal Tensor[Int](30))
+    assert(torch.einsum("i,i", b, b) equal Tensor(30))
     // matrix vector multiplication
-    assert(torch.einsum("ij,j", a, b) equal Tensor[Int](Seq(30, 80, 130, 180, 230)))
+    assert(torch.einsum("ij,j", a, b) equal Tensor(Seq(30, 80, 130, 180, 230)))
   }
 
   test("trace") {
     val t = torch.arange(1f, 10f).view(3, 3)
-    assert(torch.trace(t) equal Tensor[Float](15f))
+    assert(torch.trace(t) equal Tensor(15f))
   }
 }

--- a/core/src/test/scala/torch/ops/ReductionOpsSuite.scala
+++ b/core/src/test/scala/torch/ops/ReductionOpsSuite.scala
@@ -123,7 +123,7 @@ class ReductionOpsSuite extends TensorCheckSuite {
   )
 
   test("mean with nan") {
-    assert(mean(Tensor[Float](Seq(Float.NaN, 1, 2))).isnan.item)
+    assert(mean(Tensor(Seq(Float.NaN, 1, 2))).isnan.item)
   }
 
   testUnaryOp(
@@ -157,8 +157,8 @@ class ReductionOpsSuite extends TensorCheckSuite {
   test("mode") {
     torch.manualSeed(0)
     assertEquals(
-      torch.mode(Tensor[Int](Seq(6, 5, 1, 0, 2)), 0),
-      TensorTuple(Tensor(0), Tensor[Long](3L))
+      torch.mode(Tensor(Seq(6, 5, 1, 0, 2)), 0),
+      TensorTuple(Tensor(0), Tensor(3L))
     )
   }
 

--- a/vision/src/main/scala/torchvision/datasets/MNIST.scala
+++ b/vision/src/main/scala/torchvision/datasets/MNIST.scala
@@ -27,6 +27,7 @@ import java.util.zip.GZIPInputStream
 import scala.util.Try
 import scala.util.Success
 import scala.util.Failure
+import torch.Tensor.fromNative
 
 trait MNISTBase(
     val mirrors: Seq[String],
@@ -67,7 +68,10 @@ trait MNISTBase(
   private val native = pytorch.MNIST(root.toString(), mode)
 
   private val ds =
-    TensorDataset(Tensor[Float32](native.images().clone()), Tensor[Int64](native.targets().clone()))
+    TensorDataset(
+      fromNative[Float32](native.images().clone()),
+      fromNative[Int64](native.targets().clone())
+    )
   export ds.{apply, length, features, targets}
 
   override def toString(): String = ds.toString()


### PR DESCRIPTION
Overloading apply on Tensor for creating tensors from native LibTorch tensors leads ambiguity and confusion in some cases, so we want to avoid that.