### PR TITLE
Update to JavaCPP 1.5.10 stable and update device types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,10 +26,10 @@ ThisBuild / apiURL := Some(new URL("https://storch.dev/api/"))
 val scrImageVersion = "4.0.34"
 val pytorchVersion = "2.1.2"
 val cudaVersion = "12.3-8.9"
-val openblasVersion = "0.3.25"
+val openblasVersion = "0.3.26"
 val mklVersion = "2024.0"
 ThisBuild / scalaVersion := "3.3.1"
-ThisBuild / javaCppVersion := "1.5.10-SNAPSHOT"
+ThisBuild / javaCppVersion := "1.5.10"
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))

--- a/core/src/main/scala/torch/Device.scala
+++ b/core/src/main/scala/torch/Device.scala
@@ -20,9 +20,8 @@ import org.bytedeco.pytorch
 import scala.collection.immutable.ArraySeq
 
 enum DeviceType:
-  case CPU, CUDA, MKLDNN, OPENGL, OPENCL, IDEEP, HIP, FPGA, ORT, XLA, Vulkan, Metal, XPU, MLC, Meta,
-    HPU, VE, Lazy,
-    COMPILE_TIME_MAX_DEVICE_TYPES
+  case CPU, CUDA, MKLDNN, OPENGL, OPENCL, IDEEP, HIP, FPGA, ORT, XLA, Vulkan, Metal, XPU, MPS, Meta,
+    HPU, VE, Lazy, IPU, MTIA, PrivateUse1, COMPILE_TIME_MAX_DEVICE_TYPES
 
 object DeviceType:
   val deviceTypesLowerCase: Seq[String] =


### PR DESCRIPTION
This means we finally have no snapshot dependencies and could perhaps also release a first non-snapshot version, probably `0.0.1`.